### PR TITLE
feat(compiler-vapor): support custom directives argument & modifiers

### DIFF
--- a/packages/compiler-vapor/__tests__/__snapshots__/compile.test.ts.snap
+++ b/packages/compiler-vapor/__tests__/__snapshots__/compile.test.ts.snap
@@ -16,6 +16,78 @@ export function render(_ctx) {
 }"
 `;
 
+exports[`compile > directives > custom directive > basic 1`] = `
+"import { template as _template, children as _children, withDirectives as _withDirectives } from 'vue/vapor';
+
+export function render(_ctx) {
+  const t0 = _template("<div></div>")
+  const n0 = t0()
+  const { 0: [n1],} = _children(n0)
+  _withDirectives(n1, [[_ctx.vExample, undefined]])
+  return n0
+}"
+`;
+
+exports[`compile > directives > custom directive > binding value 1`] = `
+"import { template as _template, children as _children, withDirectives as _withDirectives } from 'vue/vapor';
+
+export function render(_ctx) {
+  const t0 = _template("<div></div>")
+  const n0 = t0()
+  const { 0: [n1],} = _children(n0)
+  _withDirectives(n1, [[_ctx.vExample, _ctx.msg, undefined]])
+  return n0
+}"
+`;
+
+exports[`compile > directives > custom directive > dynamic parameters 1`] = `
+"import { template as _template, children as _children, withDirectives as _withDirectives } from 'vue/vapor';
+
+export function render(_ctx) {
+  const t0 = _template("<div></div>")
+  const n0 = t0()
+  const { 0: [n1],} = _children(n0)
+  _withDirectives(n1, [[_ctx.vExample, _ctx.msg, _ctx.foo]])
+  return n0
+}"
+`;
+
+exports[`compile > directives > custom directive > modifiers 1`] = `
+"import { template as _template, children as _children, withDirectives as _withDirectives } from 'vue/vapor';
+
+export function render(_ctx) {
+  const t0 = _template("<div></div>")
+  const n0 = t0()
+  const { 0: [n1],} = _children(n0)
+  _withDirectives(n1, [[_ctx.vExample, _ctx.msg, undefined, { bar: true }]])
+  return n0
+}"
+`;
+
+exports[`compile > directives > custom directive > static parameters  1`] = `
+"import { template as _template, children as _children, withDirectives as _withDirectives } from 'vue/vapor';
+
+export function render(_ctx) {
+  const t0 = _template("<div></div>")
+  const n0 = t0()
+  const { 0: [n1],} = _children(n0)
+  _withDirectives(n1, [[_ctx.vExample, _ctx.msg, "foo"]])
+  return n0
+}"
+`;
+
+exports[`compile > directives > custom directive > static parameters and modifiers 1`] = `
+"import { template as _template, children as _children, withDirectives as _withDirectives } from 'vue/vapor';
+
+export function render(_ctx) {
+  const t0 = _template("<div></div>")
+  const n0 = t0()
+  const { 0: [n1],} = _children(n0)
+  _withDirectives(n1, [[_ctx.vExample, _ctx.msg, "foo", { bar: true }]])
+  return n0
+}"
+`;
+
 exports[`compile > directives > v-bind > .camel modifier 1`] = `
 "import { template as _template, children as _children, effect as _effect, setAttr as _setAttr } from 'vue/vapor';
 

--- a/packages/compiler-vapor/__tests__/__snapshots__/compile.test.ts.snap
+++ b/packages/compiler-vapor/__tests__/__snapshots__/compile.test.ts.snap
@@ -59,7 +59,7 @@ export function render(_ctx) {
   const t0 = _template("<div></div>")
   const n0 = t0()
   const { 0: [n1],} = _children(n0)
-  _withDirectives(n1, [[_ctx.vExample, _ctx.msg, undefined, { bar: true }]])
+  _withDirectives(n1, [[_ctx.vExample, _ctx.msg, void 0, { bar: true }]])
   return n0
 }"
 `;
@@ -71,7 +71,7 @@ export function render(_ctx) {
   const t0 = _template("<div></div>")
   const n0 = t0()
   const { 0: [n1],} = _children(n0)
-  _withDirectives(n1, [[_ctx.vExample, undefined, undefined, { bar: true }]])
+  _withDirectives(n1, [[_ctx.vExample, void 0, void 0, { "foo-bar": true }]])
   return n0
 }"
 `;

--- a/packages/compiler-vapor/__tests__/__snapshots__/compile.test.ts.snap
+++ b/packages/compiler-vapor/__tests__/__snapshots__/compile.test.ts.snap
@@ -23,7 +23,7 @@ export function render(_ctx) {
   const t0 = _template("<div></div>")
   const n0 = t0()
   const { 0: [n1],} = _children(n0)
-  _withDirectives(n1, [[_ctx.vExample, undefined]])
+  _withDirectives(n1, [[_ctx.vExample]])
   return n0
 }"
 `;
@@ -35,7 +35,7 @@ export function render(_ctx) {
   const t0 = _template("<div></div>")
   const n0 = t0()
   const { 0: [n1],} = _children(n0)
-  _withDirectives(n1, [[_ctx.vExample, _ctx.msg, undefined]])
+  _withDirectives(n1, [[_ctx.vExample, _ctx.msg]])
   return n0
 }"
 `;
@@ -64,7 +64,19 @@ export function render(_ctx) {
 }"
 `;
 
-exports[`compile > directives > custom directive > static parameters  1`] = `
+exports[`compile > directives > custom directive > modifiers w/o binding 1`] = `
+"import { template as _template, children as _children, withDirectives as _withDirectives } from 'vue/vapor';
+
+export function render(_ctx) {
+  const t0 = _template("<div></div>")
+  const n0 = t0()
+  const { 0: [n1],} = _children(n0)
+  _withDirectives(n1, [[_ctx.vExample, undefined, undefined, { bar: true }]])
+  return n0
+}"
+`;
+
+exports[`compile > directives > custom directive > static parameters 1`] = `
 "import { template as _template, children as _children, withDirectives as _withDirectives } from 'vue/vapor';
 
 export function render(_ctx) {

--- a/packages/compiler-vapor/__tests__/compile.test.ts
+++ b/packages/compiler-vapor/__tests__/compile.test.ts
@@ -352,7 +352,8 @@ describe('compile', () => {
         })
         expect(code).matchSnapshot()
       })
-      test('static parameters ', async () => {
+
+      test('static parameters', async () => {
         const code = await compile(`<div v-example:foo="msg"></div>`, {
           bindingMetadata: {
             msg: BindingTypes.SETUP_REF,
@@ -361,6 +362,7 @@ describe('compile', () => {
         })
         expect(code).matchSnapshot()
       })
+
       test('modifiers', async () => {
         const code = await compile(`<div v-example.bar="msg"></div>`, {
           bindingMetadata: {
@@ -370,6 +372,16 @@ describe('compile', () => {
         })
         expect(code).matchSnapshot()
       })
+
+      test('modifiers w/o binding', async () => {
+        const code = await compile(`<div v-example.bar></div>`, {
+          bindingMetadata: {
+            vExample: BindingTypes.SETUP_CONST,
+          },
+        })
+        expect(code).matchSnapshot()
+      })
+
       test('static parameters and modifiers', async () => {
         const code = await compile(`<div v-example:foo.bar="msg"></div>`, {
           bindingMetadata: {

--- a/packages/compiler-vapor/__tests__/compile.test.ts
+++ b/packages/compiler-vapor/__tests__/compile.test.ts
@@ -1,10 +1,10 @@
 import {
-  BindingTypes,
-  DOMErrorCodes,
-  ErrorCodes,
   type RootNode,
+  BindingTypes,
+  ErrorCodes,
+  DOMErrorCodes,
 } from '@vue/compiler-dom'
-import { compile as _compile, type CompilerOptions } from '../src'
+import { type CompilerOptions, compile as _compile } from '../src'
 
 function compile(template: string | RootNode, options: CompilerOptions = {}) {
   let { code } = _compile(template, {

--- a/packages/compiler-vapor/__tests__/compile.test.ts
+++ b/packages/compiler-vapor/__tests__/compile.test.ts
@@ -374,7 +374,7 @@ describe('compile', () => {
       })
 
       test('modifiers w/o binding', async () => {
-        const code = await compile(`<div v-example.bar></div>`, {
+        const code = await compile(`<div v-example.foo-bar></div>`, {
           bindingMetadata: {
             vExample: BindingTypes.SETUP_CONST,
           },

--- a/packages/compiler-vapor/__tests__/compile.test.ts
+++ b/packages/compiler-vapor/__tests__/compile.test.ts
@@ -1,10 +1,10 @@
 import {
-  type RootNode,
   BindingTypes,
-  ErrorCodes,
   DOMErrorCodes,
+  ErrorCodes,
+  type RootNode,
 } from '@vue/compiler-dom'
-import { type CompilerOptions, compile as _compile } from '../src'
+import { compile as _compile, type CompilerOptions } from '../src'
 
 function compile(template: string | RootNode, options: CompilerOptions = {}) {
   let { code } = _compile(template, {
@@ -330,6 +330,54 @@ describe('compile', () => {
         const code = await compile(`<div v-cloak>test</div>`)
         expect(code).toMatchSnapshot()
         expect(code).not.contains('v-cloak')
+      })
+    })
+
+    describe('custom directive', () => {
+      test('basic', async () => {
+        const code = await compile(`<div v-example></div>`, {
+          bindingMetadata: {
+            vExample: BindingTypes.SETUP_CONST,
+          },
+        })
+        expect(code).matchSnapshot()
+      })
+
+      test('binding value', async () => {
+        const code = await compile(`<div v-example="msg"></div>`, {
+          bindingMetadata: {
+            msg: BindingTypes.SETUP_REF,
+            vExample: BindingTypes.SETUP_CONST,
+          },
+        })
+        expect(code).matchSnapshot()
+      })
+      test('static parameters ', async () => {
+        const code = await compile(`<div v-example:foo="msg"></div>`, {
+          bindingMetadata: {
+            msg: BindingTypes.SETUP_REF,
+            vExample: BindingTypes.SETUP_CONST,
+          },
+        })
+        expect(code).matchSnapshot()
+      })
+      test('modifiers', async () => {
+        const code = await compile(`<div v-example.bar="msg"></div>`, {
+          bindingMetadata: {
+            msg: BindingTypes.SETUP_REF,
+            vExample: BindingTypes.SETUP_CONST,
+          },
+        })
+        expect(code).matchSnapshot()
+      })
+      test('static parameters and modifiers', async () => {
+        const code = await compile(`<div v-example:foo.bar="msg"></div>`, {
+          bindingMetadata: {
+            msg: BindingTypes.SETUP_REF,
+            vExample: BindingTypes.SETUP_CONST,
+          },
+        })
+        expect(code).matchSnapshot()
       })
     })
   })

--- a/packages/compiler-vapor/__tests__/compile.test.ts
+++ b/packages/compiler-vapor/__tests__/compile.test.ts
@@ -379,6 +379,16 @@ describe('compile', () => {
         })
         expect(code).matchSnapshot()
       })
+
+      test('dynamic parameters', async () => {
+        const code = await compile(`<div v-example:[foo]="msg"></div>`, {
+          bindingMetadata: {
+            foo: BindingTypes.SETUP_REF,
+            vExample: BindingTypes.SETUP_CONST,
+          },
+        })
+        expect(code).matchSnapshot()
+      })
     })
   })
 

--- a/packages/compiler-vapor/src/generate.ts
+++ b/packages/compiler-vapor/src/generate.ts
@@ -488,7 +488,6 @@ function genWithDirective(oper: WithDirectiveIRNode, context: CodegenContext) {
 
   if (oper.arg) {
     push(', ')
-    // TODO dynamic arg
     genExpression(oper.arg, context)
   } else {
     push(', undefined')

--- a/packages/compiler-vapor/src/generate.ts
+++ b/packages/compiler-vapor/src/generate.ts
@@ -469,34 +469,35 @@ function genSetEvent(oper: SetEventIRNode, context: CodegenContext) {
 
 function genWithDirective(oper: WithDirectiveIRNode, context: CodegenContext) {
   const { push, pushWithNewline, vaporHelper, bindingMetadata } = context
+  const { dir } = oper
 
   // TODO merge directive for the same node
   pushWithNewline(`${vaporHelper('withDirectives')}(n${oper.element}, [[`)
 
   // TODO resolve directive
-  const directiveReference = camelize(`v-${oper.name}`)
+  const directiveReference = camelize(`v-${dir.name}`)
   if (bindingMetadata[directiveReference]) {
     const directiveExpression = createSimpleExpression(directiveReference)
     directiveExpression.ast = null
     genExpression(directiveExpression, context)
   }
 
-  if (oper.binding) {
+  if (dir.exp) {
     push(', ')
-    genExpression(oper.binding, context)
+    genExpression(dir.exp, context)
   }
 
-  if (oper.arg) {
+  if (dir.arg) {
     push(', ')
-    genExpression(oper.arg, context)
+    genExpression(dir.arg, context)
   } else {
     push(', undefined')
   }
 
-  if (oper.modifiers && oper.modifiers.length) {
+  if (dir.modifiers && dir.modifiers.length) {
     push(', ')
     push('{ ')
-    push(genDirectiveModifiers(oper.modifiers))
+    push(genDirectiveModifiers(dir.modifiers))
     push(' }')
   }
   push(']])')

--- a/packages/compiler-vapor/src/generate.ts
+++ b/packages/compiler-vapor/src/generate.ts
@@ -485,16 +485,18 @@ function genWithDirective(oper: WithDirectiveIRNode, context: CodegenContext) {
   if (dir.exp) {
     push(', ')
     genExpression(dir.exp, context)
+  } else if (dir.arg || dir.modifiers.length) {
+    push(', undefined')
   }
 
   if (dir.arg) {
     push(', ')
     genExpression(dir.arg, context)
-  } else {
+  } else if (dir.modifiers.length) {
     push(', undefined')
   }
 
-  if (dir.modifiers && dir.modifiers.length) {
+  if (dir.modifiers.length) {
     push(', ')
     push('{ ')
     push(genDirectiveModifiers(dir.modifiers))

--- a/packages/compiler-vapor/src/generate.ts
+++ b/packages/compiler-vapor/src/generate.ts
@@ -485,6 +485,19 @@ function genWithDirective(oper: WithDirectiveIRNode, context: CodegenContext) {
     push(', ')
     genExpression(oper.binding, context)
   }
+
+  // TODO dynamic arg
+  if (oper.arg) {
+    push(', ')
+    genExpression(oper.arg, context)
+  }
+
+  if (oper.modifiers) {
+    push(', ')
+    push('{ ')
+    push(genDirectiveModifiers(oper.modifiers))
+    push(' }')
+  }
   push(']])')
   return
 }
@@ -575,4 +588,8 @@ function genIdentifier(
     id = `_ctx.${id}`
   }
   push(id, NewlineType.None, loc, name)
+}
+
+function genDirectiveModifiers(modifiers: string[]) {
+  return modifiers.map((value) => `${value}: true`).join(', ')
 }

--- a/packages/compiler-vapor/src/generate.ts
+++ b/packages/compiler-vapor/src/generate.ts
@@ -10,6 +10,7 @@ import {
   createSimpleExpression,
   walkIdentifiers,
   advancePositionWithClone,
+  isSimpleIdentifier,
 } from '@vue/compiler-dom'
 import {
   type IRDynamicChildren,
@@ -486,14 +487,14 @@ function genWithDirective(oper: WithDirectiveIRNode, context: CodegenContext) {
     push(', ')
     genExpression(dir.exp, context)
   } else if (dir.arg || dir.modifiers.length) {
-    push(', undefined')
+    push(', void 0')
   }
 
   if (dir.arg) {
     push(', ')
     genExpression(dir.arg, context)
   } else if (dir.modifiers.length) {
-    push(', undefined')
+    push(', void 0')
   }
 
   if (dir.modifiers.length) {
@@ -595,5 +596,10 @@ function genIdentifier(
 }
 
 function genDirectiveModifiers(modifiers: string[]) {
-  return modifiers.map((value) => `${value}: true`).join(', ')
+  return modifiers
+    .map(
+      (value) =>
+        `${isSimpleIdentifier(value) ? value : JSON.stringify(value)}: true`,
+    )
+    .join(', ')
 }

--- a/packages/compiler-vapor/src/generate.ts
+++ b/packages/compiler-vapor/src/generate.ts
@@ -486,13 +486,15 @@ function genWithDirective(oper: WithDirectiveIRNode, context: CodegenContext) {
     genExpression(oper.binding, context)
   }
 
-  // TODO dynamic arg
   if (oper.arg) {
     push(', ')
+    // TODO dynamic arg
     genExpression(oper.arg, context)
+  } else {
+    push(', undefined')
   }
 
-  if (oper.modifiers) {
+  if (oper.modifiers && oper.modifiers.length) {
     push(', ')
     push('{ ')
     push(genDirectiveModifiers(oper.modifiers))

--- a/packages/compiler-vapor/src/ir.ts
+++ b/packages/compiler-vapor/src/ir.ts
@@ -118,6 +118,8 @@ export interface WithDirectiveIRNode extends BaseIRNode {
   type: IRNodeTypes.WITH_DIRECTIVE
   element: number
   name: string
+  arg: IRExpression | undefined
+  modifiers: string[]
   binding: IRExpression | undefined
 }
 

--- a/packages/compiler-vapor/src/ir.ts
+++ b/packages/compiler-vapor/src/ir.ts
@@ -117,10 +117,7 @@ export interface AppendNodeIRNode extends BaseIRNode {
 export interface WithDirectiveIRNode extends BaseIRNode {
   type: IRNodeTypes.WITH_DIRECTIVE
   element: number
-  name: string
-  arg: IRExpression | undefined
-  modifiers: string[]
-  binding: IRExpression | undefined
+  dir: VaporDirectiveNode
 }
 
 export type IRNode =

--- a/packages/compiler-vapor/src/transforms/transformElement.ts
+++ b/packages/compiler-vapor/src/transforms/transformElement.ts
@@ -71,7 +71,6 @@ function transformProp(
   if (directiveTransform) {
     directiveTransform(prop, node, context)
   } else if (!isBuiltInDirective(name)) {
-    // TODO dynamic arg
     context.registerOperation({
       type: IRNodeTypes.WITH_DIRECTIVE,
       element: context.reference(),

--- a/packages/compiler-vapor/src/transforms/transformElement.ts
+++ b/packages/compiler-vapor/src/transforms/transformElement.ts
@@ -66,6 +66,7 @@ function transformProp(
     return
   }
 
+  const { arg, exp, loc, modifiers } = prop
   const directiveTransform = context.options.directiveTransforms[name]
   if (directiveTransform) {
     directiveTransform(prop, node, context)
@@ -75,8 +76,10 @@ function transformProp(
       type: IRNodeTypes.WITH_DIRECTIVE,
       element: context.reference(),
       name,
-      binding: prop.exp,
-      loc: prop.loc,
+      binding: exp,
+      arg,
+      modifiers,
+      loc: loc,
     })
   }
 }

--- a/packages/compiler-vapor/src/transforms/transformElement.ts
+++ b/packages/compiler-vapor/src/transforms/transformElement.ts
@@ -71,7 +71,7 @@ function transformProp(
   if (directiveTransform) {
     directiveTransform(prop, node, context)
   } else if (!isBuiltInDirective(name)) {
-    // custom directive
+    // TODO dynamic arg
     context.registerOperation({
       type: IRNodeTypes.WITH_DIRECTIVE,
       element: context.reference(),

--- a/packages/compiler-vapor/src/transforms/transformElement.ts
+++ b/packages/compiler-vapor/src/transforms/transformElement.ts
@@ -59,14 +59,13 @@ function transformProp(
   node: ElementNode,
   context: TransformContext<ElementNode>,
 ): void {
-  const { name } = prop
+  const { name, loc } = prop
   if (prop.type === NodeTypes.ATTRIBUTE) {
     context.template += ` ${name}`
     if (prop.value) context.template += `="${prop.value.content}"`
     return
   }
 
-  const { arg, exp, loc, modifiers } = prop
   const directiveTransform = context.options.directiveTransforms[name]
   if (directiveTransform) {
     directiveTransform(prop, node, context)
@@ -74,10 +73,7 @@ function transformProp(
     context.registerOperation({
       type: IRNodeTypes.WITH_DIRECTIVE,
       element: context.reference(),
-      name,
-      binding: exp,
-      arg,
-      modifiers,
+      dir: prop,
       loc: loc,
     })
   }

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -279,7 +279,8 @@ export type {
   DirectiveHook,
   ObjectDirective,
   FunctionDirective,
-  DirectiveArguments
+  DirectiveArguments,
+  DirectiveModifiers
 } from './directives'
 export type { SuspenseBoundary } from './components/Suspense'
 export type {

--- a/packages/runtime-vapor/src/directives.ts
+++ b/packages/runtime-vapor/src/directives.ts
@@ -1,13 +1,12 @@
 import { isFunction } from '@vue/shared'
 import { currentInstance, type ComponentInternalInstance } from './component'
-
+import type { DirectiveModifiers } from '@vue/runtime-dom'
 export interface DirectiveBinding<V = any> {
   instance: ComponentInternalInstance | null
   value: V
   oldValue: V | null
   arg?: string
-  // TODO: should we support modifiers for custom directives?
-  // modifiers: DirectiveModifiers
+  modifiers?: DirectiveModifiers
   dir: ObjectDirective<any, V>
 }
 
@@ -41,6 +40,12 @@ export type DirectiveArguments = Array<
   | [Directive | undefined]
   | [Directive | undefined, value: any]
   | [Directive | undefined, value: any, argument: string]
+  | [
+      Directive | undefined,
+      value: any,
+      argument: string,
+      modifiers: DirectiveModifiers,
+    ]
 >
 
 export function withDirectives<T extends Node>(
@@ -56,7 +61,7 @@ export function withDirectives<T extends Node>(
   const bindings = currentInstance.dirs.get(node)!
 
   for (const directive of directives) {
-    let [dir, value, arg] = directive
+    let [dir, value, arg, modifiers] = directive
     if (!dir) continue
     if (isFunction(dir)) {
       // TODO function directive
@@ -71,6 +76,7 @@ export function withDirectives<T extends Node>(
       value,
       oldValue: void 0,
       arg,
+      modifiers,
     }
     if (dir.created) dir.created(node, binding)
     bindings.push(binding)

--- a/playground/src/directive.vue
+++ b/playground/src/directive.vue
@@ -21,5 +21,5 @@ const vDirective: ObjectDirective<HTMLDivElement, undefined> = {
 </script>
 
 <template>
-  <div v-directive:foo.bar ="text" v-text="text"/>
+  <div v-directive:foo.bar="text" v-text="text" />
 </template>

--- a/playground/src/directive.vue
+++ b/playground/src/directive.vue
@@ -21,5 +21,5 @@ const vDirective: ObjectDirective<HTMLDivElement, undefined> = {
 </script>
 
 <template>
-  <div v-directive v-text="text" />
+  <div v-directive:foo.bar ="text" v-text="text"/>
 </template>


### PR DESCRIPTION
close: #33 

`<div v- example:foo.bar = 'text'>`

#### transform

`_withDirectives(n1, [[_ctx.vExample, _ctx.msg, \\"foo\\", { bar: true }]])`

Dynamic parameters need to wait for the `genExpression` and instruction update life cycles to be completed before they can be implemented.