### PR TITLE
test: compound expression for `v-bind`

### DIFF
--- a/packages/compiler-vapor/__tests__/__snapshots__/compile.test.ts.snap
+++ b/packages/compiler-vapor/__tests__/__snapshots__/compile.test.ts.snap
@@ -16,6 +16,20 @@ export function render(_ctx) {
 }"
 `;
 
+exports[`compile > directives > v-bind > dynamic arg 1`] = `
+"import { template as _template, children as _children, effect as _effect, setAttr as _setAttr } from 'vue/vapor';
+
+export function render(_ctx) {
+  const t0 = _template(\\"<div></div>\\")
+  const n0 = t0()
+  const { 0: [n1],} = _children(n0)
+  _effect(() => {
+    _setAttr(n1, _ctx.id, undefined, _ctx.id)
+  })
+  return n0
+}"
+`;
+
 exports[`compile > directives > v-bind > simple expression 1`] = `
 "import { template as _template, children as _children, effect as _effect, setAttr as _setAttr } from 'vue/vapor';
 

--- a/packages/compiler-vapor/__tests__/__snapshots__/compile.test.ts.snap
+++ b/packages/compiler-vapor/__tests__/__snapshots__/compile.test.ts.snap
@@ -20,11 +20,11 @@ exports[`compile > directives > v-bind > .camel modifier 1`] = `
 "import { template as _template, children as _children, effect as _effect, setAttr as _setAttr } from 'vue/vapor';
 
 export function render(_ctx) {
-  const t0 = _template(\\"<div></div>\\")
+  const t0 = _template("<div></div>")
   const n0 = t0()
   const { 0: [n1],} = _children(n0)
   _effect(() => {
-    _setAttr(n1, \\"foo-bar\\", undefined, _ctx.id)
+    _setAttr(n1, "foo-bar", undefined, _ctx.id)
   })
   return n0
 }"
@@ -34,7 +34,7 @@ exports[`compile > directives > v-bind > dynamic arg 1`] = `
 "import { template as _template, children as _children, effect as _effect, setAttr as _setAttr } from 'vue/vapor';
 
 export function render(_ctx) {
-  const t0 = _template(\\"<div></div>\\")
+  const t0 = _template("<div></div>")
   const n0 = t0()
   const { 0: [n1],} = _children(n0)
   _effect(() => {
@@ -48,7 +48,7 @@ exports[`compile > directives > v-bind > should error if no expression 1`] = `
 "import { template as _template } from 'vue/vapor';
 
 export function render(_ctx) {
-  const t0 = _template(\\"<div></div>\\")
+  const t0 = _template("<div></div>")
   const n0 = t0()
   return n0
 }"

--- a/packages/compiler-vapor/__tests__/__snapshots__/compile.test.ts.snap
+++ b/packages/compiler-vapor/__tests__/__snapshots__/compile.test.ts.snap
@@ -16,6 +16,20 @@ export function render(_ctx) {
 }"
 `;
 
+exports[`compile > directives > v-bind > .camel modifier 1`] = `
+"import { template as _template, children as _children, effect as _effect, setAttr as _setAttr } from 'vue/vapor';
+
+export function render(_ctx) {
+  const t0 = _template(\\"<div></div>\\")
+  const n0 = t0()
+  const { 0: [n1],} = _children(n0)
+  _effect(() => {
+    _setAttr(n1, \\"foo-bar\\", undefined, _ctx.id)
+  })
+  return n0
+}"
+`;
+
 exports[`compile > directives > v-bind > dynamic arg 1`] = `
 "import { template as _template, children as _children, effect as _effect, setAttr as _setAttr } from 'vue/vapor';
 
@@ -26,6 +40,16 @@ export function render(_ctx) {
   _effect(() => {
     _setAttr(n1, _ctx.id, undefined, _ctx.id)
   })
+  return n0
+}"
+`;
+
+exports[`compile > directives > v-bind > should error if no expression 1`] = `
+"import { template as _template } from 'vue/vapor';
+
+export function render(_ctx) {
+  const t0 = _template(\\"<div></div>\\")
+  const n0 = t0()
   return n0
 }"
 `;

--- a/packages/compiler-vapor/__tests__/__snapshots__/compile.test.ts.snap
+++ b/packages/compiler-vapor/__tests__/__snapshots__/compile.test.ts.snap
@@ -314,6 +314,30 @@ export function render(_ctx) {
 }"
 `;
 
+exports[`compile > expression parsing > interpolation 1`] = `
+"(() => {
+  const t0 = _fragment()
+
+  const n0 = t0()
+  _effect(() => {
+    _setText(n0, undefined, a + b.value)
+  })
+  return n0
+})()"
+`;
+
+exports[`compile > expression parsing > v-bind 1`] = `
+"(() => {
+  const t0 = _template("<div></div>")
+  const n0 = t0()
+  const { 0: [n1],} = _children(n0)
+  _effect(() => {
+    _setAttr(n1, key.value+1, undefined, _unref(foo)[key.value+1]())
+  })
+  return n0
+})()"
+`;
+
 exports[`compile > fragment 1`] = `
 "import { template as _template } from 'vue/vapor';
 

--- a/packages/compiler-vapor/__tests__/compile.test.ts
+++ b/packages/compiler-vapor/__tests__/compile.test.ts
@@ -89,6 +89,33 @@ describe('compile', () => {
           },
         })
       })
+
+      // TODO: fix this test
+      test.fails('no expression (shorthand)', async () => {
+        const code = await compile('<div :id />', {
+          bindingMetadata: {
+            id: BindingTypes.SETUP_REF,
+          },
+        })
+
+        expect(code).matchSnapshot()
+        expect(code).contains(
+          JSON.stringify('_setAttr(n1, "id", undefined, _ctx.id)'),
+        )
+      })
+
+      test.fails('dynamic arg', async () => {
+        const code = await compile('<div v-bind:[id]="id"/>', {
+          bindingMetadata: {
+            id: BindingTypes.SETUP_REF,
+          },
+        })
+
+        expect(code).matchSnapshot()
+        expect(code).contains(
+          JSON.stringify('_setAttr(n1, _ctx.id, undefined, _ctx.id)'),
+        )
+      })
     })
 
     describe('v-on', () => {
@@ -124,8 +151,8 @@ describe('compile', () => {
           `<a @click.stop="handleEvent"></a>
             <form @submit.prevent="handleEvent"></form>
             <a @click.stop.prevent="handleEvent"></a>
-            <div @click.self="handleEvent"></div> 
-            <div @click.capture="handleEvent"></div> 
+            <div @click.self="handleEvent"></div>
+            <div @click.capture="handleEvent"></div>
             <a @click.once="handleEvent"></a>
             <div @scroll.passive="handleEvent"></div>
             <input @click.right="handleEvent" />

--- a/packages/compiler-vapor/__tests__/compile.test.ts
+++ b/packages/compiler-vapor/__tests__/compile.test.ts
@@ -95,7 +95,7 @@ describe('compile', () => {
         expect(code).contains(JSON.stringify('<div arg="" ></div>'))
       })
 
-      // TODO: shorthand for v-bind
+      // TODO: support shorthand syntax for v-bind #9451
       test.fails('no expression', async () => {
         const code = await compile('<div v-bind:id />', {
           bindingMetadata: {
@@ -107,7 +107,7 @@ describe('compile', () => {
         expect(code).contains('_setAttr(n1, "id", undefined, _ctx.id)')
       })
 
-      // TODO: shorthand for v-bind
+      // TODO: support shorthand syntax for v-bind #9451
       test.fails('no expression (shorthand)', async () => {
         const code = await compile('<div :id />', {
           bindingMetadata: {

--- a/packages/compiler-vapor/__tests__/compile.test.ts
+++ b/packages/compiler-vapor/__tests__/compile.test.ts
@@ -334,4 +334,32 @@ describe('compile', () => {
       })
     })
   })
+
+  describe('expression parsing', () => {
+    test('interpolation', async () => {
+      const code = await compile(`{{ a + b }}`, {
+        inline: true,
+        bindingMetadata: {
+          b: BindingTypes.SETUP_REF,
+        },
+      })
+      expect(code).matchSnapshot()
+      expect(code).contains('a + b.value')
+    })
+
+    test('v-bind', async () => {
+      const code = compile(`<div :[key+1]="foo[key+1]()" />`, {
+        inline: true,
+        bindingMetadata: {
+          key: BindingTypes.SETUP_REF,
+          foo: BindingTypes.SETUP_MAYBE_REF,
+        },
+      })
+      expect(code).matchSnapshot()
+      expect(code).contains('key.value+1')
+      expect(code).contains('_unref(foo)[key.value+1]()')
+    })
+
+    // TODO: add more test for expression parsing (v-on, v-slot, v-for)
+  })
 })

--- a/packages/compiler-vapor/__tests__/compile.test.ts
+++ b/packages/compiler-vapor/__tests__/compile.test.ts
@@ -104,7 +104,7 @@ describe('compile', () => {
         })
 
         expect(code).matchSnapshot()
-        expect(code).contains('_setAttr(n1, \\"id\\", undefined, _ctx.id)')
+        expect(code).contains('_setAttr(n1, "id", undefined, _ctx.id)')
       })
 
       // TODO: shorthand for v-bind
@@ -116,7 +116,7 @@ describe('compile', () => {
         })
 
         expect(code).matchSnapshot()
-        expect(code).contains('_setAttr(n1, \\"id\\", undefined, _ctx.id)')
+        expect(code).contains('_setAttr(n1, "id", undefined, _ctx.id)')
       })
 
       test('dynamic arg', async () => {


### PR DESCRIPTION
close #35 

This is a unit test PR related to the complex expression parsing of v-bind in Vue Vapor.

In addition to complex expressions, I also added some other tests related to `v-bind`.

I referred to the existing tests related to `v-bind` in `/packages/compiler-core` when adding these tests.