### PR TITLE
test: add all tests for `v-on`

### DIFF
--- a/packages/compiler-vapor/__tests__/transforms/vHtml.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/vHtml.spec.ts
@@ -80,6 +80,9 @@ describe('v-html', () => {
     expect(ir.vaporHelpers).contains('setHtml')
     expect(ir.helpers.size).toBe(0)
 
+    // children should have been removed
+    expect(ir.template).toMatchObject([{ template: '<div></div>' }])
+
     expect(ir.operation).toEqual([])
     expect(ir.effect).toMatchObject([
       {
@@ -109,6 +112,8 @@ describe('v-html', () => {
     ])
 
     expect(code).matchSnapshot()
+    // children should have been removed
+    expect(code).contains('template("<div></div>")')
   })
 
   test('should raise error if has no expression', () => {

--- a/packages/compiler-vapor/__tests__/transforms/vOn.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/vOn.spec.ts
@@ -1,28 +1,80 @@
-import { type RootNode, BindingTypes, ErrorCodes } from '@vue/compiler-dom'
-import { type CompilerOptions, compile as _compile } from '../../src'
+import {
+  type RootNode,
+  BindingTypes,
+  ErrorCodes,
+  parse,
+  NodeTypes,
+} from '@vue/compiler-dom'
+import {
+  type CompilerOptions,
+  compile as _compile,
+  RootIRNode,
+  transform,
+  generate,
+  IRNodeTypes,
+} from '../../src'
 
-function compile(template: string | RootNode, options: CompilerOptions = {}) {
-  let { code } = _compile(template, {
-    ...options,
-    mode: 'module',
+import { transformVOn } from '../../src/transforms/vOn'
+import { transformElement } from '../../src/transforms/transformElement'
+
+function compileWithVHtml(
+  template: string,
+  options: CompilerOptions = {},
+): {
+  ir: RootIRNode
+  code: string
+} {
+  const ast = parse(template, { prefixIdentifiers: true, ...options })
+  const ir = transform(ast, {
+    nodeTransforms: [transformElement],
+    directiveTransforms: {
+      on: transformVOn,
+    },
     prefixIdentifiers: true,
+    ...options,
   })
-  return code
+  const { code } = generate(ir, { prefixIdentifiers: true, ...options })
+  return { ir, code }
 }
 
 describe('v-on', () => {
   test('simple expression', () => {
-    const code = compile(`<div @click="handleClick"></div>`, {
+    const { code, ir } = compileWithVHtml(`<div @click="handleClick"></div>`, {
       bindingMetadata: {
         handleClick: BindingTypes.SETUP_CONST,
       },
     })
+    console.log('ir.operation\n', ir.operation)
+
+    expect(ir.vaporHelpers).contains('on')
+    expect(ir.helpers.size).toBe(0)
+    expect(ir.effect).toEqual([])
+
+    expect(ir.operation).toMatchObject([
+      {
+        type: IRNodeTypes.SET_EVENT,
+        element: 1,
+        key: {
+          type: NodeTypes.SIMPLE_EXPRESSION,
+          content: 'click',
+          isStatic: true,
+        },
+        value: {
+          type: NodeTypes.SIMPLE_EXPRESSION,
+          content: 'handleClick',
+          isStatic: false,
+        },
+        modifiers: { keys: [], nonKeys: [], options: [] },
+        keyOverride: undefined,
+      },
+    ])
+
     expect(code).matchSnapshot()
   })
 
   test('should error if no expression AND no modifier', () => {
     const onError = vi.fn()
-    compile(`<div v-on:click />`, { onError })
+    compileWithVHtml(`<div v-on:click />`, { onError })
     expect(onError.mock.calls[0][0]).toMatchObject({
       code: ErrorCodes.X_V_ON_NO_EXPRESSION,
       loc: {
@@ -39,7 +91,7 @@ describe('v-on', () => {
   })
 
   test('event modifier', () => {
-    const code = compile(
+    const { code } = compileWithVHtml(
       `<a @click.stop="handleEvent"></a>
         <form @submit.prevent="handleEvent"></form>
         <a @click.stop.prevent="handleEvent"></a>


### PR DESCRIPTION
Refer to the `v-on` unit test in the compiler-core/dom, and finish the remaining unit tests for v-on in Vapor.