### PR TITLE
refactor: improve file path resolution

### DIFF
--- a/playground/setup/dev.js
+++ b/playground/setup/dev.js
@@ -1,7 +1,8 @@
 // @ts-check
 import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 
-const dirname = path.dirname(new URL(import.meta.url).pathname)
+const dirname = path.dirname(fileURLToPath(new URL(import.meta.url)))
 const resolve = (/** @type {string} */ p) =>
   path.resolve(dirname, '../../packages', p)
 


### PR DESCRIPTION
The commit updates the method of converting URLs to file paths in development setup. Using 'fileURLToPath' from Node's URL module has replaced the earlier approach, enhancing reliability and efficiency of file path resolution.