### PR TITLE
feat(runtime-vapor): scheduler

### DIFF
--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -1,6 +1,6 @@
 import { EffectScope, Ref, ref } from '@vue/reactivity'
 
-import { EMPTY_OBJ } from '@vue/shared'
+import { EMPTY_OBJ, isFunction } from '@vue/shared'
 import { Block } from './render'
 import { type DirectiveBinding } from './directive'
 import {
@@ -215,4 +215,14 @@ export const createComponentInstance = (
     // [VaporLifecycleHooks.SERVER_PREFETCH]: null,
   }
   return instance
+}
+
+export const getComponentname = (instance: ComponentInternalInstance) => {
+  /**
+   * TODO:
+   *   ref. packages/runtime-core/src/components.ts L1112.
+   *   component.__name, component.name, component.displayName need.
+   *
+   */
+  return isFunction(instance.component) ? instance.component.name : ''
 }

--- a/packages/runtime-vapor/src/scheduler.ts
+++ b/packages/runtime-vapor/src/scheduler.ts
@@ -1,30 +1,265 @@
-import { ReactiveEffect } from '@vue/reactivity'
+import { NOOP, isArray } from '@vue/shared'
+import { ComponentInternalInstance, ReactiveEffect } from '.'
+import { warn } from './warn'
+import { getComponentname } from './component'
 
-const p = Promise.resolve()
+export interface SchedulerJob extends Function {
+  id?: number
+  pre?: boolean
+  active?: boolean
+  computed?: boolean
+  /**
+   * Indicates whether the effect is allowed to recursively trigger itself
+   * when managed by the scheduler.
+   *
+   * By default, a job cannot trigger itself because some built-in method calls,
+   * e.g. Array.prototype.push actually performs reads as well (#1740) which
+   * can lead to confusing infinite loops.
+   * The allowed cases are component update functions and watch callbacks.
+   * Component update functions may update child component props, which in turn
+   * trigger flush: "pre" watch callbacks that mutates state that the parent
+   * relies on (#1801). Watch callbacks doesn't track its dependencies so if it
+   * triggers itself again, it's likely intentional and it is the user's
+   * responsibility to perform recursive state mutation that eventually
+   * stabilizes (#1727).
+   */
+  allowRecurse?: boolean
+  /**
+   * Attached by renderer.ts when setting up a component's render effect
+   * Used to obtain component information when reporting max recursive updates.
+   * dev only.
+   */
+  ownerInstance?: ComponentInternalInstance
+}
 
-let queued: any[] | undefined
+export type SchedulerJobs = SchedulerJob | SchedulerJob[]
 
-function queue(fn: any) {
-  if (!queued) {
-    queued = [fn]
-    p.then(flush)
+let isFlushing = false
+let isFlushPending = false
+
+const queued: SchedulerJob[] = []
+let flushIndex = 0
+
+const pendingPostFlushCbs: SchedulerJob[] = []
+let activePostFlushCbs: SchedulerJob[] | null = null
+let postFlushIndex = 0
+
+const resolvedPromise = /*#__PURE__*/ Promise.resolve() as Promise<any>
+let currentFlushPromise: Promise<void> | null = null
+
+const RECURSION_LIMIT = 100
+type CountMap = Map<SchedulerJob, number>
+
+export function queueJob(job: SchedulerJob) {
+  if (
+    !queued.length ||
+    !queued.includes(
+      job,
+      isFlushing && job.allowRecurse ? flushIndex + 1 : flushIndex,
+    )
+  ) {
+    if (job.id == null) {
+      queued.push(job)
+    } else {
+      queued.splice(findInsertionIndex(job.id), 0, job)
+    }
+    queueFlush()
+  }
+}
+
+function queueFlush() {
+  if (!isFlushing && !isFlushPending) {
+    isFlushPending = true
+    currentFlushPromise = resolvedPromise.then(flushJobs)
+  }
+}
+
+export function invalidateJob(job: SchedulerJob) {
+  const i = queued.indexOf(job)
+  if (i > flushIndex) {
+    queued.splice(i, 1)
+  }
+}
+export function queuePostFlushCb(cb: SchedulerJobs) {
+  if (!isArray(cb)) {
+    if (
+      !activePostFlushCbs ||
+      !activePostFlushCbs.includes(
+        cb,
+        cb.allowRecurse ? postFlushIndex + 1 : postFlushIndex,
+      )
+    ) {
+      pendingPostFlushCbs.push(cb)
+    }
   } else {
-    queued.push(fn)
+    // if cb is an array, it is a component lifecycle hook which can only be
+    // triggered by a job, which is already deduped in the main queue, so
+    // we can skip duplicate check here to improve perf
+    pendingPostFlushCbs.push(...cb)
+  }
+  queueFlush()
+}
+
+export function flushPreFlushCbs(
+  seen?: CountMap,
+  // if currently flushing, skip the current job itself
+  i = isFlushing ? flushIndex + 1 : 0,
+) {
+  if (__DEV__) {
+    seen = seen || new Map()
+  }
+  for (; i < queued.length; i++) {
+    const cb = queued[i]
+    if (cb && cb.pre) {
+      if (__DEV__ && checkRecursiveUpdates(seen!, cb)) {
+        continue
+      }
+      queued.splice(i, 1)
+      i--
+      cb()
+    }
   }
 }
 
-function flush() {
-  for (let i = 0; i < queued!.length; i++) {
-    queued![i]()
+export function flushPostFlushCbs(seen?: CountMap) {
+  if (pendingPostFlushCbs.length) {
+    const deduped = [...new Set(pendingPostFlushCbs)]
+    pendingPostFlushCbs.length = 0
+
+    // #1947 already has active queue, nested flushPostFlushCbs call
+    if (activePostFlushCbs) {
+      activePostFlushCbs.push(...deduped)
+      return
+    }
+
+    activePostFlushCbs = deduped
+    if (__DEV__) {
+      seen = seen || new Map()
+    }
+
+    activePostFlushCbs.sort((a, b) => getId(a) - getId(b))
+
+    for (
+      postFlushIndex = 0;
+      postFlushIndex < activePostFlushCbs.length;
+      postFlushIndex++
+    ) {
+      if (
+        __DEV__ &&
+        checkRecursiveUpdates(seen!, activePostFlushCbs[postFlushIndex])
+      ) {
+        continue
+      }
+      activePostFlushCbs[postFlushIndex]()
+    }
+    activePostFlushCbs = null
+    postFlushIndex = 0
   }
-  queued = undefined
 }
 
-export const nextTick = (fn?: any) => (fn ? p.then(fn) : p)
+function findInsertionIndex(id: number) {
+  // the start index should be `flushIndex + 1`
+  let start = flushIndex + 1
+  let end = queued.length
 
-export function effect(fn: any) {
+  while (start < end) {
+    const middle = (start + end) >>> 1
+    const middleJob = queued[middle]
+    const middleJobId = getId(middleJob)
+    if (middleJobId < id || (middleJobId === id && middleJob.pre)) {
+      start = middle + 1
+    } else {
+      end = middle
+    }
+  }
+
+  return start
+}
+const getId = (job: SchedulerJob): number =>
+  job.id == null ? Infinity : job.id
+
+const comparator = (a: SchedulerJob, b: SchedulerJob): number => {
+  const diff = getId(a) - getId(b)
+  if (diff === 0) {
+    if (a.pre && !b.pre) return -1
+    if (b.pre && !a.pre) return 1
+  }
+  return diff
+}
+
+function flushJobs(seen?: CountMap) {
+  isFlushPending = false
+  isFlushing = true
+  if (__DEV__) {
+    seen = seen || new Map()
+  }
+  queued.sort(comparator)
+  const check = __DEV__
+    ? (job: SchedulerJob) => checkRecursiveUpdates(seen!, job)
+    : NOOP
+  try {
+    for (flushIndex = 0; flushIndex < queued.length; flushIndex++) {
+      const job = queued[flushIndex]
+      if (job && !job.active) {
+        if (__DEV__ && check(job)) {
+          continue
+        }
+        job()
+        // TODO: callWithErrorHandling(job, null, ErrorCodes.SCHEDULER)
+      }
+    }
+  } finally {
+    flushIndex = 0
+    queued.length = 0
+    flushPostFlushCbs()
+    isFlushing = false
+    currentFlushPromise = null
+    // some postFlushCb queued jobs!
+    // keep flushing until it drains.
+    if (queued.length || pendingPostFlushCbs.length) {
+      flushJobs(seen)
+    }
+  }
+}
+
+function checkRecursiveUpdates(seen: CountMap, fn: SchedulerJob) {
+  if (!seen.has(fn)) {
+    seen.set(fn, 1)
+  } else {
+    const count = seen.get(fn)!
+    if (count > RECURSION_LIMIT) {
+      const componentName =
+        fn.ownerInstance && getComponentname(fn.ownerInstance)
+      warn(
+        `Maximum recursive updates exceeded${
+          componentName ? ` in component <${componentName}>` : ``
+        }. ` +
+          `This means you have a reactive effect that is mutating its own ` +
+          `dependencies and thus recursively triggering itself. Possible sources ` +
+          `include component template, render function, updated hook or ` +
+          `watcher source function.`,
+      )
+      return true
+    } else {
+      seen.set(fn, count + 1)
+    }
+  }
+}
+
+export function nextTick<T = void, R = void>(
+  this: T,
+  fn?: (this: T) => R,
+): Promise<Awaited<R>> {
+  const p = currentFlushPromise || resolvedPromise
+  return fn ? p.then(this ? fn.bind(this) : fn) : p
+}
+
+export const effect = (fn: any) => {
   let run: () => void
-  const e = new ReactiveEffect(fn, () => queue(run))
+  const e = new ReactiveEffect(fn, () => {
+    queueJob(run)
+    queueFlush()
+  })
   run = e.run.bind(e)
   run()
 }

--- a/packages/runtime-vapor/src/warn.ts
+++ b/packages/runtime-vapor/src/warn.ts
@@ -1,0 +1,11 @@
+import { pauseTracking, resetTracking } from '@vue/reactivity'
+
+export const warn = (msg: string, ...args: any[]) => {
+  if (!__DEV__) {
+    return
+  }
+  pauseTracking()
+  // TODO: component trace need.
+  console.warn(msg)
+  resetTracking()
+}


### PR DESCRIPTION
## `scheduler.ts`
Retained the `effect` method, aligning other methods with runtime core
## `warn.ts`
Print only wanring messages without printing component context information, as the parent component cannot be obtained yet
## `component.ts`
Add `getComponentName` function, but just can get function component name. If function component name is [Falsy](https://developer.mozilla.org/en-US/docs/Glossary/Falsy) will return `''`