### PR TITLE
feat(runtime-vapor): support render function in setup

### DIFF
--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -14,7 +14,7 @@ import { VaporLifecycleHooks } from './enums'
 
 export type Component = FunctionalComponent | ObjectComponent
 
-export type SetupFn = (props: any, ctx: any) => Block | Data
+export type SetupFn = (props: any, ctx: any) => Block | Data | (() => Block)
 export type FunctionalComponent = SetupFn & {
   props: ComponentPropsOptions
   render(ctx: any): Block

--- a/packages/runtime-vapor/src/render.ts
+++ b/packages/runtime-vapor/src/render.ts
@@ -1,5 +1,5 @@
 import { proxyRefs } from '@vue/reactivity'
-import { type Data, invokeArrayFns } from '@vue/shared'
+import { type Data, invokeArrayFns, isFunction } from '@vue/shared'
 import {
   type Component,
   type ComponentInternalInstance,
@@ -62,6 +62,8 @@ export function mountComponent(
       } finally {
         isRenderingActivity = currentlyRenderingActivity
       }
+    } else if (isFunction(state)) {
+      block = state()
     } else {
       block = state as Block
     }

--- a/playground/src/setup-render.vue
+++ b/playground/src/setup-render.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { defineComponent } from 'vue'
-import { children, ref, setText, template, watchEffect } from 'vue/vapor'
+import { children, ref, setText, template, renderEffect } from 'vue/vapor'
 
 export default defineComponent({
   setup() {
@@ -16,7 +16,7 @@ export default defineComponent({
       const {
         0: [n1],
       } = children(n0)
-      watchEffect(() => {
+      renderEffect(() => {
         setText(n1, void 0, count.value)
       })
       return n0

--- a/playground/src/setup-render.vue
+++ b/playground/src/setup-render.vue
@@ -1,0 +1,26 @@
+<script lang="ts">
+import { defineComponent } from 'vue'
+import { children, ref, setText, template, watchEffect } from 'vue/vapor'
+
+export default defineComponent({
+  setup(){
+    const count = ref(1)
+
+    setInterval(() => {
+      count.value++
+    }, 1000)
+
+    return ()=> {
+      const t0 = template('<p></p>')
+      const n0 = t0()
+      const {
+        0: [n1],
+      } = children(n0)
+      watchEffect(() => {
+        setText(n1, void 0, count.value)
+      })
+      return n0
+    }
+  }
+})
+</script>

--- a/playground/src/setup-render.vue
+++ b/playground/src/setup-render.vue
@@ -3,14 +3,14 @@ import { defineComponent } from 'vue'
 import { children, ref, setText, template, watchEffect } from 'vue/vapor'
 
 export default defineComponent({
-  setup(){
+  setup() {
     const count = ref(1)
 
     setInterval(() => {
       count.value++
     }, 1000)
 
-    return ()=> {
+    return () => {
       const t0 = template('<p></p>')
       const n0 = t0()
       const {
@@ -21,6 +21,6 @@ export default defineComponent({
       })
       return n0
     }
-  }
+  },
 })
 </script>


### PR DESCRIPTION
```vue
<script lang="ts">
import { template } from 'vue/vapor'

export default {
  setup(){

    return () => {
      const t0 = template('<p>123</p>')
      const n0 = t0()
      return n0
    }
  }
}
</script>
```