### PR TITLE
fix(compiler-vapor): should not prefix member expression

### DIFF
--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/vOn.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/vOn.spec.ts.snap
@@ -226,6 +226,18 @@ export function render(_ctx) {
 }"
 `;
 
+exports[`v-on > should not prefix member expression 1`] = `
+"import { template as _template, children as _children, on as _on } from 'vue/vapor';
+
+export function render(_ctx) {
+  const t0 = _template("<div></div>")
+  const n0 = t0()
+  const { 0: [n1],} = _children(n0)
+  _on(n1, "click", (...args) => (_ctx.foo.bar && _ctx.foo.bar(...args)))
+  return n0
+}"
+`;
+
 exports[`v-on > should not wrap keys guard if no key modifier is present 1`] = `
 "import { template as _template, children as _children, on as _on, withModifiers as _withModifiers } from 'vue/vapor';
 

--- a/packages/compiler-vapor/__tests__/transforms/vOn.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/vOn.spec.ts
@@ -707,4 +707,15 @@ describe('v-on', () => {
       '(_ctx.event) === "click" ? "mouseup" : (_ctx.event)',
     )
   })
+
+  test('should not prefix member expression', () => {
+    const { code } = compileWithVOn(`<div @click="foo.bar"/>`, {
+      prefixIdentifiers: true,
+    })
+
+    expect(code).matchSnapshot()
+    expect(code).contains(
+      `_on(n1, "click", (...args) => (_ctx.foo.bar && _ctx.foo.bar(...args)))`,
+    )
+  })
 })

--- a/packages/compiler-vapor/src/generate.ts
+++ b/packages/compiler-vapor/src/generate.ts
@@ -652,7 +652,7 @@ function genExpression(
       if (isLocal) return
       ids.push(id)
     },
-    true,
+    false,
     [],
     knownIds,
   )


### PR DESCRIPTION
Before:
```ts
_setText(n1, undefined, _ctx.foo._ctx.bar)
```

After:
```ts
_setText(n1, undefined, _ctx.foo.bar)
```