### PR TITLE
feat(compiler-vapor): complex identifier rewriting with vOn

### DIFF
--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/vOn.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/vOn.spec.ts.snap
@@ -353,6 +353,18 @@ export function render(_ctx) {
 }"
 `;
 
+exports[`v-on > should wrap in unref if identifier is setup-maybe-ref w/ inline: true 1`] = `
+"(() => {
+  const t0 = _template("<div></div><div></div><div></div>")
+  const n0 = t0()
+  const { 0: [n1], 1: [n2], 2: [n3],} = _children(n0)
+  _on(n1, "click", $event => (x.value=_unref(y)))
+  _on(n2, "click", $event => (x.value++))
+  _on(n3, "click", $event => ({ x: x.value } = _unref(y)))
+  return n0
+})()"
+`;
+
 exports[`v-on > should wrap keys guard for keyboard events or dynamic events 1`] = `
 "import { template as _template, children as _children, withModifiers as _withModifiers, withKeys as _withKeys, on as _on } from 'vue/vapor';
 

--- a/packages/compiler-vapor/__tests__/transforms/vOn.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/vOn.spec.ts
@@ -170,6 +170,29 @@ describe('v-on', () => {
     expect(code).contains('_on(n1, "click", $event => (_ctx.i++))')
   })
 
+  test('should wrap in unref if identifier is setup-maybe-ref w/ inline: true', () => {
+    const { code, helpers, vaporHelpers } = compileWithVOn(
+      `<div @click="x=y"/><div @click="x++"/><div @click="{ x } = y"/>`,
+      {
+        mode: 'module',
+        inline: true,
+        bindingMetadata: {
+          x: BindingTypes.SETUP_MAYBE_REF,
+          y: BindingTypes.SETUP_MAYBE_REF,
+        },
+      },
+    )
+    expect(code).matchSnapshot()
+
+    expect(vaporHelpers).contains('unref')
+    expect(helpers.size).toBe(0)
+    expect(code).contains('_on(n1, "click", $event => (x.value=_unref(y)))')
+    expect(code).contains('_on(n2, "click", $event => (x.value++))')
+    expect(code).contains(
+      '_on(n3, "click", $event => ({ x: x.value } = _unref(y)))',
+    )
+  })
+
   test('should handle multiple inline statement', () => {
     const { ir, code } = compileWithVOn(`<div @click="foo();bar()"/>`)
 

--- a/packages/compiler-vapor/src/generators/expression.ts
+++ b/packages/compiler-vapor/src/generators/expression.ts
@@ -45,7 +45,7 @@ export function genExpression(
 
   // the expression is a simple identifier
   if (ast === null) {
-    return [genIdentifier(rawExpr, context, loc)]
+    return genIdentifier(rawExpr, context, loc)
   }
 
   const ids: Identifier[] = []
@@ -75,7 +75,7 @@ export function genExpression(
       const source = rawExpr.slice(start, end)
       const parentStack = parentStackMap.get(id)!
       push(
-        genIdentifier(
+        ...genIdentifier(
           source,
           context,
           {
@@ -108,16 +108,16 @@ function genIdentifier(
   id?: Identifier,
   parent?: Node,
   parentStack?: Node[],
-): CodeFragment {
+): CodeFragment[] {
   const { inline, bindingMetadata } = options
   let name: string | undefined = raw
 
   const idMap = identifiers[raw]
   if (idMap && idMap.length) {
-    return [idMap[0], NewlineType.None, loc]
+    return [[idMap[0], NewlineType.None, loc]]
   }
 
-  let prefix = ''
+  let prefix: string | undefined
   if (isStaticProperty(parent!) && parent.shorthand) {
     // property shorthand like { foo }, we need to add the key since
     // we rewrite the value
@@ -152,5 +152,5 @@ function genIdentifier(
   } else {
     raw = `_ctx.${raw}`
   }
-  return [prefix + raw, NewlineType.None, loc, name]
+  return [prefix, [raw, NewlineType.None, loc, name]]
 }


### PR DESCRIPTION
I found that some expressions are having issues being parsed in inline mode.

the examples

```vue
<div @click="x=y"/>
<div @click="x++"/>
<div @click="{ x } = y"/>
```

compilation results:

```js
_on(n1, "click", $event => (_unref(x) = _unref(y)))
_on(n2, "click", $event => (_unref(x)++))
_on(n3, "click", $event => ({ _unref(x) } = _unref(y)))
```

