### PR TITLE
feat(compiler-vapor): props merging

### DIFF
--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/transformElement.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/transformElement.spec.ts.snap
@@ -1,0 +1,56 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`compiler: element transform > props merging: class 1`] = `
+"import { template as _template, children as _children, renderEffect as _renderEffect, setClass as _setClass } from 'vue/vapor';
+
+export function render(_ctx) {
+  const t0 = _template("<div></div>")
+  const n0 = t0()
+  const { 0: [n1],} = _children(n0)
+  _renderEffect(() => {
+    _setClass(n1, ["foo", { bar: _ctx.isBar }])
+  })
+  return n0
+}"
+`;
+
+exports[`compiler: element transform > props merging: event handlers 1`] = `
+"import { template as _template, children as _children, on as _on } from 'vue/vapor';
+
+export function render(_ctx) {
+  const t0 = _template("<div></div>")
+  const n0 = t0()
+  const { 0: [n1],} = _children(n0)
+  _on(n1, "click", (...args) => (_ctx.a && _ctx.a(...args)))
+  _on(n1, "click", (...args) => (_ctx.b && _ctx.b(...args)))
+  return n0
+}"
+`;
+
+exports[`compiler: element transform > props merging: style 1`] = `
+"import { template as _template, children as _children, renderEffect as _renderEffect, setStyle as _setStyle } from 'vue/vapor';
+
+export function render(_ctx) {
+  const t0 = _template("<div></div>")
+  const n0 = t0()
+  const { 0: [n1],} = _children(n0)
+  _renderEffect(() => {
+    _setStyle(n1, ["color: green", { color: 'red' }])
+  })
+  return n0
+}"
+`;
+
+exports[`compiler: element transform > props merging: style w/ transformExpression 1`] = `
+"import { template as _template, children as _children, renderEffect as _renderEffect, setStyle as _setStyle } from 'vue/vapor';
+
+export function render(_ctx) {
+  const t0 = _template("<div></div>")
+  const n0 = t0()
+  const { 0: [n1],} = _children(n0)
+  _renderEffect(() => {
+    _setStyle(n1, ["color: green", { color: 'red' }])
+  })
+  return n0
+}"
+`;

--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/transformElement.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/transformElement.spec.ts.snap
@@ -40,17 +40,3 @@ export function render(_ctx) {
   return n0
 }"
 `;
-
-exports[`compiler: element transform > props merging: style w/ transformExpression 1`] = `
-"import { template as _template, children as _children, renderEffect as _renderEffect, setStyle as _setStyle } from 'vue/vapor';
-
-export function render(_ctx) {
-  const t0 = _template("<div></div>")
-  const n0 = t0()
-  const { 0: [n1],} = _children(n0)
-  _renderEffect(() => {
-    _setStyle(n1, ["color: green", { color: 'red' }])
-  })
-  return n0
-}"
-`;

--- a/packages/compiler-vapor/__tests__/transforms/__snapshots__/transformElement.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/transforms/__snapshots__/transformElement.spec.ts.snap
@@ -14,19 +14,6 @@ export function render(_ctx) {
 }"
 `;
 
-exports[`compiler: element transform > props merging: event handlers 1`] = `
-"import { template as _template, children as _children, on as _on } from 'vue/vapor';
-
-export function render(_ctx) {
-  const t0 = _template("<div></div>")
-  const n0 = t0()
-  const { 0: [n1],} = _children(n0)
-  _on(n1, "click", (...args) => (_ctx.a && _ctx.a(...args)))
-  _on(n1, "click", (...args) => (_ctx.b && _ctx.b(...args)))
-  return n0
-}"
-`;
-
 exports[`compiler: element transform > props merging: style 1`] = `
 "import { template as _template, children as _children, renderEffect as _renderEffect, setStyle as _setStyle } from 'vue/vapor';
 

--- a/packages/compiler-vapor/__tests__/transforms/transformElement.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/transformElement.spec.ts
@@ -1,2 +1,188 @@
-// TODO: add tests for this transform
-test('baisc', () => {})
+import { makeCompile } from './_utils'
+import {
+  IRNodeTypes,
+  transformElement,
+  transformInterpolation,
+  transformVBind,
+  transformVOn,
+  transformVText,
+} from '../../src'
+import { NodeTypes } from '@vue/compiler-core'
+
+const compileWithElementTransform = makeCompile({
+  nodeTransforms: [transformInterpolation, transformElement],
+  directiveTransforms: {
+    bind: transformVBind,
+    on: transformVOn,
+    text: transformVText,
+  },
+})
+
+describe('compiler: element transform', () => {
+  test.todo('baisc')
+
+  // This v-on feature comes from the unit tests of compiler-core,
+  // but I am not sure if Vapor needs this feature.
+  test.fails('props merging: event handlers', () => {
+    const { code, ir } = compileWithElementTransform(
+      `<div @click.foo="a" @click.bar="b" />`,
+    )
+    expect(code).toMatchSnapshot()
+
+    expect(ir.operation).toMatchObject([
+      {
+        type: IRNodeTypes.SET_EVENT,
+        element: 1,
+        key: {
+          type: NodeTypes.SIMPLE_EXPRESSION,
+          content: 'click',
+          isStatic: true,
+        },
+        value: [
+          {
+            type: NodeTypes.SIMPLE_EXPRESSION,
+            content: `a`,
+            isStatic: false,
+          },
+          {
+            type: NodeTypes.SIMPLE_EXPRESSION,
+            content: `b`,
+            isStatic: false,
+          },
+        ],
+      },
+    ])
+  })
+
+  test('props merging: style', () => {
+    const { code, ir } = compileWithElementTransform(
+      `<div style="color: green" :style="{ color: 'red' }" />`,
+      {
+        prefixIdentifiers: false,
+      },
+    )
+    expect(code).toMatchSnapshot()
+
+    expect(ir.effect).toMatchObject([
+      {
+        expressions: [
+          {
+            type: NodeTypes.SIMPLE_EXPRESSION,
+            content: `{ color: 'red' }`,
+            isStatic: false,
+          },
+        ],
+        operations: [
+          {
+            type: IRNodeTypes.SET_PROP,
+            element: 1,
+            prop: {
+              key: {
+                type: NodeTypes.SIMPLE_EXPRESSION,
+                content: 'style',
+                isStatic: true,
+              },
+              value: [
+                {
+                  type: NodeTypes.SIMPLE_EXPRESSION,
+                  content: 'color: green',
+                  isStatic: true,
+                },
+                {
+                  type: NodeTypes.SIMPLE_EXPRESSION,
+                  content: `{ color: 'red' }`,
+                  isStatic: false,
+                },
+              ],
+            },
+          },
+        ],
+      },
+    ])
+  })
+
+  test('props merging: style w/ transformExpression', () => {
+    const { code, ir } = compileWithElementTransform(
+      `<div style="color: green" :style="{ color: 'red' }" />`,
+      {
+        prefixIdentifiers: true,
+      },
+    )
+    expect(code).toMatchSnapshot()
+
+    expect(ir.effect).toMatchObject([
+      {
+        operations: [
+          {
+            type: IRNodeTypes.SET_PROP,
+            element: 1,
+            prop: {
+              key: {
+                type: NodeTypes.SIMPLE_EXPRESSION,
+                content: 'style',
+                isStatic: true,
+              },
+              value: [
+                {
+                  type: NodeTypes.SIMPLE_EXPRESSION,
+                  content: 'color: green',
+                  isStatic: true,
+                },
+                {
+                  type: NodeTypes.SIMPLE_EXPRESSION,
+                  content: `{ color: 'red' }`,
+                  isStatic: false,
+                },
+              ],
+            },
+          },
+        ],
+      },
+    ])
+  })
+
+  test('props merging: class', () => {
+    const { code, ir } = compileWithElementTransform(
+      `<div class="foo" :class="{ bar: isBar }" />`,
+    )
+
+    expect(code).toMatchSnapshot()
+
+    expect(ir.effect).toMatchObject([
+      {
+        expressions: [
+          {
+            type: NodeTypes.SIMPLE_EXPRESSION,
+            content: `{ bar: isBar }`,
+            isStatic: false,
+          },
+        ],
+        operations: [
+          {
+            type: IRNodeTypes.SET_PROP,
+            element: 1,
+            prop: {
+              key: {
+                type: NodeTypes.SIMPLE_EXPRESSION,
+                content: 'class',
+                isStatic: true,
+              },
+              value: [
+                {
+                  type: NodeTypes.SIMPLE_EXPRESSION,
+                  content: `foo`,
+                  isStatic: true,
+                },
+                {
+                  type: NodeTypes.SIMPLE_EXPRESSION,
+                  content: `{ bar: isBar }`,
+                  isStatic: false,
+                },
+              ],
+            },
+          },
+        ],
+      },
+    ])
+  })
+})

--- a/packages/compiler-vapor/__tests__/transforms/transformElement.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/transformElement.spec.ts
@@ -18,9 +18,7 @@ const compileWithElementTransform = makeCompile({
 describe('compiler: element transform', () => {
   test.todo('baisc')
 
-  // This v-on feature comes from the unit tests of compiler-core,
-  // but I am not sure if Vapor needs this feature.
-  test.fails('props merging: event handlers', () => {
+  test.todo('props merging: event handlers', () => {
     const { code, ir } = compileWithElementTransform(
       `<div @click.foo="a" @click.bar="b" />`,
     )
@@ -35,16 +33,21 @@ describe('compiler: element transform', () => {
           content: 'click',
           isStatic: true,
         },
-        value: [
+        events: [
           {
-            type: NodeTypes.SIMPLE_EXPRESSION,
-            content: `a`,
-            isStatic: false,
+            // IREvent: value, modifiers, keyOverride...
+            value: {
+              type: NodeTypes.SIMPLE_EXPRESSION,
+              content: `a`,
+              isStatic: false,
+            },
           },
           {
-            type: NodeTypes.SIMPLE_EXPRESSION,
-            content: `b`,
-            isStatic: false,
+            value: {
+              type: NodeTypes.SIMPLE_EXPRESSION,
+              content: `b`,
+              isStatic: false,
+            },
           },
         ],
       },

--- a/packages/compiler-vapor/__tests__/transforms/transformElement.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/transformElement.spec.ts
@@ -2,19 +2,16 @@ import { makeCompile } from './_utils'
 import {
   IRNodeTypes,
   transformElement,
-  transformInterpolation,
   transformVBind,
   transformVOn,
-  transformVText,
 } from '../../src'
 import { NodeTypes } from '@vue/compiler-core'
 
 const compileWithElementTransform = makeCompile({
-  nodeTransforms: [transformInterpolation, transformElement],
+  nodeTransforms: [transformElement],
   directiveTransforms: {
     bind: transformVBind,
     on: transformVOn,
-    text: transformVText,
   },
 })
 
@@ -57,9 +54,6 @@ describe('compiler: element transform', () => {
   test('props merging: style', () => {
     const { code, ir } = compileWithElementTransform(
       `<div style="color: green" :style="{ color: 'red' }" />`,
-      {
-        prefixIdentifiers: false,
-      },
     )
     expect(code).toMatchSnapshot()
 
@@ -72,46 +66,6 @@ describe('compiler: element transform', () => {
             isStatic: false,
           },
         ],
-        operations: [
-          {
-            type: IRNodeTypes.SET_PROP,
-            element: 1,
-            prop: {
-              key: {
-                type: NodeTypes.SIMPLE_EXPRESSION,
-                content: 'style',
-                isStatic: true,
-              },
-              value: [
-                {
-                  type: NodeTypes.SIMPLE_EXPRESSION,
-                  content: 'color: green',
-                  isStatic: true,
-                },
-                {
-                  type: NodeTypes.SIMPLE_EXPRESSION,
-                  content: `{ color: 'red' }`,
-                  isStatic: false,
-                },
-              ],
-            },
-          },
-        ],
-      },
-    ])
-  })
-
-  test('props merging: style w/ transformExpression', () => {
-    const { code, ir } = compileWithElementTransform(
-      `<div style="color: green" :style="{ color: 'red' }" />`,
-      {
-        prefixIdentifiers: true,
-      },
-    )
-    expect(code).toMatchSnapshot()
-
-    expect(ir.effect).toMatchObject([
-      {
         operations: [
           {
             type: IRNodeTypes.SET_PROP,

--- a/packages/compiler-vapor/__tests__/transforms/transformElement.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/transformElement.spec.ts
@@ -76,7 +76,7 @@ describe('compiler: element transform', () => {
                 content: 'style',
                 isStatic: true,
               },
-              value: [
+              values: [
                 {
                   type: NodeTypes.SIMPLE_EXPRESSION,
                   content: 'color: green',
@@ -121,7 +121,7 @@ describe('compiler: element transform', () => {
                 content: 'class',
                 isStatic: true,
               },
-              value: [
+              values: [
                 {
                   type: NodeTypes.SIMPLE_EXPRESSION,
                   content: `foo`,

--- a/packages/compiler-vapor/__tests__/transforms/vBind.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/vBind.spec.ts
@@ -52,16 +52,18 @@ describe('compiler v-bind', () => {
                 source: 'id',
               },
             },
-            value: {
-              type: NodeTypes.SIMPLE_EXPRESSION,
-              content: 'id',
-              isStatic: false,
-              loc: {
-                source: 'id',
-                start: { line: 1, column: 17, offset: 16 },
-                end: { line: 1, column: 19, offset: 18 },
+            values: [
+              {
+                type: NodeTypes.SIMPLE_EXPRESSION,
+                content: 'id',
+                isStatic: false,
+                loc: {
+                  source: 'id',
+                  start: { line: 1, column: 17, offset: 16 },
+                  end: { line: 1, column: 19, offset: 18 },
+                },
               },
-            },
+            ],
             loc: {
               start: { column: 6, line: 1, offset: 5 },
               end: { column: 20, line: 1, offset: 19 },
@@ -92,14 +94,16 @@ describe('compiler v-bind', () => {
             end: { line: 1, column: 15, offset: 14 },
           },
         },
-        value: {
-          content: `id`,
-          isStatic: false,
-          loc: {
-            start: { line: 1, column: 13, offset: 12 },
-            end: { line: 1, column: 15, offset: 14 },
+        values: [
+          {
+            content: `id`,
+            isStatic: false,
+            loc: {
+              start: { line: 1, column: 13, offset: 12 },
+              end: { line: 1, column: 15, offset: 14 },
+            },
           },
-        },
+        ],
       },
     })
     expect(code).contains('_setDynamicProp(n1, "id", _ctx.id)')
@@ -116,10 +120,12 @@ describe('compiler v-bind', () => {
           content: `camel-case`,
           isStatic: true,
         },
-        value: {
-          content: `camelCase`,
-          isStatic: false,
-        },
+        values: [
+          {
+            content: `camelCase`,
+            isStatic: false,
+          },
+        ],
       },
     })
     expect(code).contains('_setDynamicProp(n1, "camel-case", _ctx.camelCase)')
@@ -141,11 +147,13 @@ describe('compiler v-bind', () => {
               content: 'id',
               isStatic: false,
             },
-            value: {
-              type: NodeTypes.SIMPLE_EXPRESSION,
-              content: 'id',
-              isStatic: false,
-            },
+            values: [
+              {
+                type: NodeTypes.SIMPLE_EXPRESSION,
+                content: 'id',
+                isStatic: false,
+              },
+            ],
           },
           {
             key: {
@@ -153,11 +161,13 @@ describe('compiler v-bind', () => {
               content: 'title',
               isStatic: false,
             },
-            value: {
-              type: NodeTypes.SIMPLE_EXPRESSION,
-              content: 'title',
-              isStatic: false,
-            },
+            values: [
+              {
+                type: NodeTypes.SIMPLE_EXPRESSION,
+                content: 'title',
+                isStatic: false,
+              },
+            ],
           },
         ],
       ],
@@ -183,11 +193,13 @@ describe('compiler v-bind', () => {
               content: 'id',
               isStatic: false,
             },
-            value: {
-              type: NodeTypes.SIMPLE_EXPRESSION,
-              content: 'id',
-              isStatic: false,
-            },
+            values: [
+              {
+                type: NodeTypes.SIMPLE_EXPRESSION,
+                content: 'id',
+                isStatic: false,
+              },
+            ],
           },
           {
             key: {
@@ -195,11 +207,13 @@ describe('compiler v-bind', () => {
               content: 'foo',
               isStatic: true,
             },
-            value: {
-              type: NodeTypes.SIMPLE_EXPRESSION,
-              content: 'bar',
-              isStatic: true,
-            },
+            values: [
+              {
+                type: NodeTypes.SIMPLE_EXPRESSION,
+                content: 'bar',
+                isStatic: true,
+              },
+            ],
           },
           {
             key: {
@@ -247,10 +261,12 @@ describe('compiler v-bind', () => {
           content: `fooBar`,
           isStatic: true,
         },
-        value: {
-          content: `id`,
-          isStatic: false,
-        },
+        values: [
+          {
+            content: `id`,
+            isStatic: false,
+          },
+        ],
         runtimeCamelize: false,
         modifier: undefined,
       },
@@ -270,10 +286,12 @@ describe('compiler v-bind', () => {
           content: `fooBar`,
           isStatic: true,
         },
-        value: {
-          content: `fooBar`,
-          isStatic: false,
-        },
+        values: [
+          {
+            content: `fooBar`,
+            isStatic: false,
+          },
+        ],
         runtimeCamelize: false,
         modifier: undefined,
       },
@@ -294,10 +312,12 @@ describe('compiler v-bind', () => {
               content: `foo`,
               isStatic: false,
             },
-            value: {
-              content: `id`,
-              isStatic: false,
-            },
+            values: [
+              {
+                content: `id`,
+                isStatic: false,
+              },
+            ],
             runtimeCamelize: true,
             modifier: undefined,
           },
@@ -324,10 +344,12 @@ describe('compiler v-bind', () => {
           content: `fooBar`,
           isStatic: true,
         },
-        value: {
-          content: `id`,
-          isStatic: false,
-        },
+        values: [
+          {
+            content: `id`,
+            isStatic: false,
+          },
+        ],
         runtimeCamelize: false,
         modifier: '.',
       },
@@ -346,10 +368,12 @@ describe('compiler v-bind', () => {
           content: `fooBar`,
           isStatic: true,
         },
-        value: {
-          content: `fooBar`,
-          isStatic: false,
-        },
+        values: [
+          {
+            content: `fooBar`,
+            isStatic: false,
+          },
+        ],
         runtimeCamelize: false,
         modifier: '.',
       },
@@ -371,10 +395,12 @@ describe('compiler v-bind', () => {
               content: `fooBar`,
               isStatic: false,
             },
-            value: {
-              content: `id`,
-              isStatic: false,
-            },
+            values: [
+              {
+                content: `id`,
+                isStatic: false,
+              },
+            ],
             runtimeCamelize: false,
             modifier: '.',
           },
@@ -399,10 +425,12 @@ describe('compiler v-bind', () => {
           content: `fooBar`,
           isStatic: true,
         },
-        value: {
-          content: `id`,
-          isStatic: false,
-        },
+        values: [
+          {
+            content: `id`,
+            isStatic: false,
+          },
+        ],
         runtimeCamelize: false,
         modifier: '.',
       },
@@ -421,10 +449,12 @@ describe('compiler v-bind', () => {
           content: `fooBar`,
           isStatic: true,
         },
-        value: {
-          content: `fooBar`,
-          isStatic: false,
-        },
+        values: [
+          {
+            content: `fooBar`,
+            isStatic: false,
+          },
+        ],
         runtimeCamelize: false,
         modifier: '.',
       },
@@ -443,10 +473,12 @@ describe('compiler v-bind', () => {
           content: `foo-bar`,
           isStatic: true,
         },
-        value: {
-          content: `id`,
-          isStatic: false,
-        },
+        values: [
+          {
+            content: `id`,
+            isStatic: false,
+          },
+        ],
         runtimeCamelize: false,
         modifier: '^',
       },
@@ -465,10 +497,12 @@ describe('compiler v-bind', () => {
           content: `foo-bar`,
           isStatic: true,
         },
-        value: {
-          content: `fooBar`,
-          isStatic: false,
-        },
+        values: [
+          {
+            content: `fooBar`,
+            isStatic: false,
+          },
+        ],
         runtimeCamelize: false,
         modifier: '^',
       },

--- a/packages/compiler-vapor/__tests__/transforms/vOnce.spec.ts
+++ b/packages/compiler-vapor/__tests__/transforms/vOnce.spec.ts
@@ -50,11 +50,13 @@ describe('compiler: v-once', () => {
             content: 'class',
             isStatic: true,
           },
-          value: {
-            type: NodeTypes.SIMPLE_EXPRESSION,
-            content: 'clz',
-            isStatic: false,
-          },
+          values: [
+            {
+              type: NodeTypes.SIMPLE_EXPRESSION,
+              content: 'clz',
+              isStatic: false,
+            },
+          ],
         },
       },
       {
@@ -81,11 +83,13 @@ describe('compiler: v-once', () => {
             content: 'id',
             isStatic: true,
           },
-          value: {
-            type: NodeTypes.SIMPLE_EXPRESSION,
-            content: 'foo',
-            isStatic: false,
-          },
+          values: [
+            {
+              type: NodeTypes.SIMPLE_EXPRESSION,
+              content: 'foo',
+              isStatic: false,
+            },
+          ],
         },
       },
     ])
@@ -111,11 +115,13 @@ describe('compiler: v-once', () => {
             content: 'id',
             isStatic: true,
           },
-          value: {
-            type: NodeTypes.SIMPLE_EXPRESSION,
-            content: 'foo',
-            isStatic: false,
-          },
+          values: [
+            {
+              type: NodeTypes.SIMPLE_EXPRESSION,
+              content: 'foo',
+              isStatic: false,
+            },
+          ],
         },
       },
     ])

--- a/packages/compiler-vapor/src/generators/prop.ts
+++ b/packages/compiler-vapor/src/generators/prop.ts
@@ -1,12 +1,9 @@
+import { NewlineType, isSimpleIdentifier } from '@vue/compiler-core'
+import { isArray } from '@vue/shared'
 import { type CodeFragment, type CodegenContext, NEWLINE } from '../generate'
 import type { SetDynamicPropsIRNode, SetPropIRNode, VaporHelper } from '../ir'
 import { genExpression } from './expression'
-import type {
-  DirectiveTransformResult,
-  DirectiveTransformResultValue,
-} from '../transform'
-import { NewlineType, isSimpleIdentifier } from '@vue/compiler-core'
-import { isArray } from '@vue/shared'
+import type { DirectiveTransformResult } from '../transform'
 
 // only the static key prop will reach here
 export function genSetProp(
@@ -117,7 +114,7 @@ function genPropertyKey(
 }
 
 function genPropValueExpression(
-  propValues: DirectiveTransformResultValue,
+  propValues: DirectiveTransformResult['value'],
   context: CodegenContext,
 ) {
   if (isArray(propValues)) {

--- a/packages/compiler-vapor/src/ir.ts
+++ b/packages/compiler-vapor/src/ir.ts
@@ -88,18 +88,21 @@ export interface FragmentFactoryIRNode extends BaseIRNode {
   type: IRNodeTypes.FRAGMENT_FACTORY
 }
 
+export interface IRProp extends Omit<DirectiveTransformResult, 'value'> {
+  values: SimpleExpressionNode[]
+}
+export type IRProps = IRProp[] | SimpleExpressionNode
+
 export interface SetPropIRNode extends BaseIRNode {
   type: IRNodeTypes.SET_PROP
   element: number
-  prop: DirectiveTransformResult
+  prop: IRProp
 }
-
-export type PropsExpression = DirectiveTransformResult[] | SimpleExpressionNode
 
 export interface SetDynamicPropsIRNode extends BaseIRNode {
   type: IRNodeTypes.SET_DYNAMIC_PROPS
   element: number
-  props: PropsExpression[]
+  props: IRProps[]
 }
 
 export interface SetTextIRNode extends BaseIRNode {

--- a/packages/compiler-vapor/src/transform.ts
+++ b/packages/compiler-vapor/src/transform.ts
@@ -44,7 +44,7 @@ export type DirectiveTransform = (
 
 export interface DirectiveTransformResult {
   key: SimpleExpressionNode
-  value: SimpleExpressionNode | SimpleExpressionNode[]
+  value: SimpleExpressionNode
   modifier?: '.' | '^'
   runtimeCamelize?: boolean
 }

--- a/packages/compiler-vapor/src/transform.ts
+++ b/packages/compiler-vapor/src/transform.ts
@@ -42,12 +42,18 @@ export type DirectiveTransform = (
   context: TransformContext<ElementNode>,
 ) => DirectiveTransformResult | void
 
-export interface DirectiveTransformResult {
+export interface DirectiveTransformResult<
+  Value extends DirectiveTransformResultValue = DirectiveTransformResultValue,
+> {
   key: SimpleExpressionNode
-  value: SimpleExpressionNode
+  value: Value
   modifier?: '.' | '^'
   runtimeCamelize?: boolean
 }
+
+export type DirectiveTransformResultValue =
+  | SimpleExpressionNode
+  | SimpleExpressionNode[]
 
 // A structural directive transform is technically also a NodeTransform;
 // Only v-if and v-for fall into this category.

--- a/packages/compiler-vapor/src/transform.ts
+++ b/packages/compiler-vapor/src/transform.ts
@@ -42,18 +42,12 @@ export type DirectiveTransform = (
   context: TransformContext<ElementNode>,
 ) => DirectiveTransformResult | void
 
-export interface DirectiveTransformResult<
-  Value extends DirectiveTransformResultValue = DirectiveTransformResultValue,
-> {
+export interface DirectiveTransformResult {
   key: SimpleExpressionNode
-  value: Value
+  value: SimpleExpressionNode | SimpleExpressionNode[]
   modifier?: '.' | '^'
   runtimeCamelize?: boolean
 }
-
-export type DirectiveTransformResultValue =
-  | SimpleExpressionNode
-  | SimpleExpressionNode[]
 
 // A structural directive transform is technically also a NodeTransform;
 // Only v-if and v-for fall into this category.

--- a/packages/compiler-vapor/src/transforms/transformElement.ts
+++ b/packages/compiler-vapor/src/transforms/transformElement.ts
@@ -194,7 +194,7 @@ function transformProp(
 
 function isStatic(
   prop: DirectiveTransformResult,
-): prop is DirectiveTransformResult<SimpleExpressionNode> {
+): prop is DirectiveTransformResult & { value: SimpleExpressionNode } {
   const { key, value } = prop
   return key.isStatic && !isArray(value) && value.isStatic
 }

--- a/packages/compiler-vapor/src/transforms/transformElement.ts
+++ b/packages/compiler-vapor/src/transforms/transformElement.ts
@@ -87,14 +87,6 @@ function buildProps(
     }
   }
 
-  // treat all props as dynamic key
-  const asDynamic = props.some(
-    prop =>
-      prop.type === NodeTypes.DIRECTIVE &&
-      prop.name === 'bind' &&
-      (!prop.arg || !prop.arg.isStatic),
-  )
-
   for (const prop of props) {
     if (
       prop.type === NodeTypes.DIRECTIVE &&
@@ -116,7 +108,7 @@ function buildProps(
     const result = transformProp(prop, node, context)
     if (result) {
       results.push(result)
-      asDynamic && pushDynamicExpressions(result.key, result.value)
+      pushDynamicExpressions(result.key, result.value)
     }
   }
 

--- a/packages/compiler-vapor/src/transforms/transformElement.ts
+++ b/packages/compiler-vapor/src/transforms/transformElement.ts
@@ -10,7 +10,6 @@ import {
 } from '@vue/compiler-dom'
 import {
   extend,
-  isArray,
   isBuiltInDirective,
   isReservedProp,
   isVoidTag,

--- a/packages/compiler-vapor/src/transforms/transformElement.ts
+++ b/packages/compiler-vapor/src/transforms/transformElement.ts
@@ -73,14 +73,10 @@ function buildProps(
   let results: DirectiveTransformResult[] = []
 
   function pushDynamicExpressions(
-    ...exprs: (SimpleExpressionNode | SimpleExpressionNode[] | undefined)[]
+    ...exprs: (SimpleExpressionNode | undefined)[]
   ) {
     for (const expr of exprs) {
-      if (isArray(expr)) {
-        pushDynamicExpressions(...expr)
-      } else if (expr && !expr.isStatic) {
-        dynamicExpr.push(expr)
-      }
+      if (expr && !expr.isStatic) dynamicExpr.push(expr)
     }
   }
 

--- a/packages/compiler-vapor/src/transforms/transformElement.ts
+++ b/packages/compiler-vapor/src/transforms/transformElement.ts
@@ -180,8 +180,6 @@ function transformProp(
 // Literal duplicated attributes would have been warned during the parse phase,
 // however, it's possible to encounter duplicated `onXXX` handlers with different
 // modifiers. We also need to merge static and dynamic class / style attributes.
-// - onXXX handlers / style: merge into array
-// - class: merge into single expression with concatenation
 function dedupeProperties(results: DirectiveTransformResult[]): IRProp[] {
   const knownProps: Map<string, IRProp> = new Map()
   const deduped: IRProp[] = []

--- a/packages/compiler-vapor/src/transforms/transformElement.ts
+++ b/packages/compiler-vapor/src/transforms/transformElement.ts
@@ -112,13 +112,10 @@ function buildProps(
     }
   }
 
-  // take rest of props as dynamic props
-  if (dynamicArgs.length || results.some(({ key }) => !key.isStatic)) {
-    pushMergeArg()
-  }
-
   // has dynamic key or v-bind="{}"
-  if (dynamicArgs.length) {
+  if (dynamicArgs.length || results.some(({ key }) => !key.isStatic)) {
+    // take rest of props as dynamic props
+    pushMergeArg()
     context.registerEffect(dynamicExpr, [
       {
         type: IRNodeTypes.SET_DYNAMIC_PROPS,

--- a/packages/compiler-vapor/src/transforms/transformElement.ts
+++ b/packages/compiler-vapor/src/transforms/transformElement.ts
@@ -183,7 +183,6 @@ function transformProp(
     return directiveTransform(prop, node, context)
   }
 
-  // is column directive
   if (!isBuiltInDirective(name)) {
     context.registerOperation({
       type: IRNodeTypes.WITH_DIRECTIVE,


### PR DESCRIPTION
This PR will support the features of `v-bind` in the code example below.

```vue
<div class="foo" :class="{ bar: isBar }" />
<div style="color: green" :style="{ color: 'red' }" />
```
