### PR TITLE
feat: directive lifecycle hooks in `v-for`, `v-if` and component

### DIFF
--- a/packages/reactivity/src/effectScope.ts
+++ b/packages/reactivity/src/effectScope.ts
@@ -34,13 +34,13 @@ export class EffectScope {
    */
   private index: number | undefined
 
-  constructor(public detached = false) {
-    this.parent = activeEffectScope
-    if (!detached && activeEffectScope) {
-      this.index =
-        (activeEffectScope.scopes || (activeEffectScope.scopes = [])).push(
-          this,
-        ) - 1
+  constructor(
+    public detached = false,
+    parent = activeEffectScope,
+  ) {
+    this.parent = parent
+    if (!detached && parent) {
+      this.index = (parent.scopes || (parent.scopes = [])).push(this) - 1
     }
   }
 

--- a/packages/runtime-vapor/__tests__/directives/vShow.spec.ts
+++ b/packages/runtime-vapor/__tests__/directives/vShow.spec.ts
@@ -77,7 +77,7 @@ describe('directive: v-show', () => {
     }).render()
 
     expect(host.innerHTML).toBe('<button>toggle</button><div>child</div>')
-    expect(instance.dirs.get(n0)![0].dir).toBe(vShow)
+    expect(instance.scope.dirs!.get(n0)![0].dir).toBe(vShow)
 
     const btn = host.querySelector('button')
     btn?.click()

--- a/packages/runtime-vapor/__tests__/if.spec.ts
+++ b/packages/runtime-vapor/__tests__/if.spec.ts
@@ -1,4 +1,5 @@
 import {
+  children,
   createIf,
   insert,
   nextTick,
@@ -6,9 +7,11 @@ import {
   renderEffect,
   setText,
   template,
+  withDirectives,
 } from '../src'
 import type { Mock } from 'vitest'
 import { makeRender } from './_utils'
+import { unmountComponent } from '../src/apiRender'
 
 const define = makeRender()
 
@@ -24,6 +27,8 @@ describe('createIf', () => {
     let spyElseFn: Mock<any, any>
     const count = ref(0)
 
+    const spyConditionFn = vi.fn(() => count.value)
+
     // templates can be reused through caching.
     const t0 = template('<div></div>')
     const t1 = template('<p></p>')
@@ -34,7 +39,7 @@ describe('createIf', () => {
 
       insert(
         createIf(
-          () => count.value,
+          spyConditionFn,
           // v-if
           (spyIfFn ||= vi.fn(() => {
             const n2 = t1()
@@ -55,24 +60,28 @@ describe('createIf', () => {
     }).render()
 
     expect(host.innerHTML).toBe('<div><p>zero</p><!--if--></div>')
+    expect(spyConditionFn).toHaveBeenCalledTimes(1)
     expect(spyIfFn!).toHaveBeenCalledTimes(0)
     expect(spyElseFn!).toHaveBeenCalledTimes(1)
 
     count.value++
     await nextTick()
     expect(host.innerHTML).toBe('<div><p>1</p><!--if--></div>')
+    expect(spyConditionFn).toHaveBeenCalledTimes(2)
     expect(spyIfFn!).toHaveBeenCalledTimes(1)
     expect(spyElseFn!).toHaveBeenCalledTimes(1)
 
     count.value++
     await nextTick()
     expect(host.innerHTML).toBe('<div><p>2</p><!--if--></div>')
+    expect(spyConditionFn).toHaveBeenCalledTimes(3)
     expect(spyIfFn!).toHaveBeenCalledTimes(1)
     expect(spyElseFn!).toHaveBeenCalledTimes(1)
 
     count.value = 0
     await nextTick()
     expect(host.innerHTML).toBe('<div><p>zero</p><!--if--></div>')
+    expect(spyConditionFn).toHaveBeenCalledTimes(4)
     expect(spyIfFn!).toHaveBeenCalledTimes(1)
     expect(spyElseFn!).toHaveBeenCalledTimes(2)
   })
@@ -123,5 +132,114 @@ describe('createIf', () => {
     ok1.value = false
     await nextTick()
     expect(host.innerHTML).toBe('<!--if-->')
+  })
+
+  test('should work with directive hooks', async () => {
+    const calls: string[] = []
+    const show1 = ref(true)
+    const show2 = ref(true)
+    const update = ref(0)
+
+    const spyConditionFn1 = vi.fn(() => show1.value)
+    const spyConditionFn2 = vi.fn(() => show2.value)
+
+    const vDirective: any = {
+      created: (el: any, { value }: any) => calls.push(`${value} created`),
+      beforeMount: (el: any, { value }: any) =>
+        calls.push(`${value} beforeMount`),
+      mounted: (el: any, { value }: any) => calls.push(`${value} mounted`),
+      beforeUpdate: (el: any, { value }: any) =>
+        calls.push(`${value} beforeUpdate`),
+      updated: (el: any, { value }: any) => calls.push(`${value} updated`),
+      beforeUnmount: (el: any, { value }: any) =>
+        calls.push(`${value} beforeUnmount`),
+      unmounted: (el: any, { value }: any) => calls.push(`${value} unmounted`),
+    }
+
+    const t0 = template('<p></p>')
+    const { instance } = define(() => {
+      const n1 = createIf(
+        spyConditionFn1,
+        () => {
+          const n2 = t0()
+          withDirectives(children(n2, 0), [
+            [vDirective, () => (update.value, '1')],
+          ])
+          return n2
+        },
+        () =>
+          createIf(
+            spyConditionFn2,
+            () => {
+              const n2 = t0()
+              withDirectives(children(n2, 0), [[vDirective, () => '2']])
+              return n2
+            },
+            () => {
+              const n2 = t0()
+              withDirectives(children(n2, 0), [[vDirective, () => '3']])
+              return n2
+            },
+          ),
+      )
+      return [n1]
+    }).render()
+
+    await nextTick()
+    expect(calls).toEqual(['1 created', '1 beforeMount', '1 mounted'])
+    calls.length = 0
+    expect(spyConditionFn1).toHaveBeenCalledTimes(1)
+    expect(spyConditionFn2).toHaveBeenCalledTimes(0)
+
+    show1.value = false
+    await nextTick()
+    expect(calls).toEqual([
+      '1 beforeUnmount',
+      '2 created',
+      '2 beforeMount',
+      '1 unmounted',
+      '2 mounted',
+    ])
+    calls.length = 0
+    expect(spyConditionFn1).toHaveBeenCalledTimes(2)
+    expect(spyConditionFn2).toHaveBeenCalledTimes(1)
+
+    show2.value = false
+    await nextTick()
+    expect(calls).toEqual([
+      '2 beforeUnmount',
+      '3 created',
+      '3 beforeMount',
+      '2 unmounted',
+      '3 mounted',
+    ])
+    calls.length = 0
+    expect(spyConditionFn1).toHaveBeenCalledTimes(2)
+    expect(spyConditionFn2).toHaveBeenCalledTimes(2)
+
+    show1.value = true
+    await nextTick()
+    expect(calls).toEqual([
+      '3 beforeUnmount',
+      '1 created',
+      '1 beforeMount',
+      '3 unmounted',
+      '1 mounted',
+    ])
+    calls.length = 0
+    expect(spyConditionFn1).toHaveBeenCalledTimes(3)
+    expect(spyConditionFn2).toHaveBeenCalledTimes(2)
+
+    update.value++
+    await nextTick()
+    expect(calls).toEqual(['1 beforeUpdate', '1 updated'])
+    calls.length = 0
+    expect(spyConditionFn1).toHaveBeenCalledTimes(3)
+    expect(spyConditionFn2).toHaveBeenCalledTimes(2)
+
+    unmountComponent(instance)
+    expect(calls).toEqual(['1 beforeUnmount', '1 unmounted'])
+    expect(spyConditionFn1).toHaveBeenCalledTimes(3)
+    expect(spyConditionFn2).toHaveBeenCalledTimes(2)
   })
 })

--- a/packages/runtime-vapor/src/apiCreateFor.ts
+++ b/packages/runtime-vapor/src/apiCreateFor.ts
@@ -1,14 +1,26 @@
-import { type EffectScope, effectScope, isReactive } from '@vue/reactivity'
+import { getCurrentScope, isReactive, traverse } from '@vue/reactivity'
 import { isArray, isObject, isString } from '@vue/shared'
-import { createComment, createTextNode, insert, remove } from './dom/element'
-import { renderEffect } from './renderEffect'
+import {
+  createComment,
+  createTextNode,
+  insert,
+  remove as removeBlock,
+} from './dom/element'
 import { type Block, type Fragment, fragmentKey } from './apiRender'
 import { warn } from './warning'
+import { currentInstance } from './component'
 import { componentKey } from './component'
+import { BlockEffectScope, isRenderEffectScope } from './blockEffectScope'
+import {
+  createChildFragmentDirectives,
+  invokeWithMount,
+  invokeWithUnmount,
+  invokeWithUpdate,
+} from './directivesChildFragment'
 import type { DynamicSlot } from './componentSlots'
 
 interface ForBlock extends Fragment {
-  scope: EffectScope
+  scope: BlockEffectScope
   /** state, use short key since it's used a lot in generated code */
   s: [item: any, key: any, index?: number]
   update: () => void
@@ -16,9 +28,11 @@ interface ForBlock extends Fragment {
   memo: any[] | undefined
 }
 
+type Source = any[] | Record<any, any> | number | Set<any> | Map<any, any>
+
 /*! #__NO_SIDE_EFFECTS__ */
 export const createFor = (
-  src: () => any[] | Record<any, any> | number | Set<any> | Map<any, any>,
+  src: () => Source,
   renderItem: (block: ForBlock) => [Block, () => void],
   getKey?: (item: any, key: any, index?: number) => any,
   getMemo?: (item: any, key: any, index?: number) => any[],
@@ -29,18 +43,34 @@ export const createFor = (
   let oldBlocks: ForBlock[] = []
   let newBlocks: ForBlock[]
   let parent: ParentNode | undefined | null
+  const update = getMemo ? updateWithMemo : updateWithoutMemo
+  const parentScope = getCurrentScope()!
   const parentAnchor = __DEV__ ? createComment('for') : createTextNode()
   const ref: Fragment = {
     nodes: oldBlocks,
     [fragmentKey]: true,
   }
-  const update = getMemo ? updateWithMemo : updateWithoutMemo
-  once ? renderList() : renderEffect(renderList)
+
+  const instance = currentInstance!
+  if (__DEV__ && (!instance || !isRenderEffectScope(parentScope))) {
+    warn('createFor() can only be used inside setup()')
+  }
+
+  createChildFragmentDirectives(
+    parentAnchor,
+    () => oldBlocks.map(b => b.scope),
+    // source getter
+    () => traverse(src(), 1),
+    // init cb
+    getValue => doFor(getValue()),
+    // effect cb
+    getValue => doFor(getValue()),
+    once,
+  )
 
   return ref
 
-  function renderList() {
-    const source = src()
+  function doFor(source: any) {
     const newLength = getLength(source)
     const oldLength = oldBlocks.length
     newBlocks = new Array(newLength)
@@ -225,7 +255,8 @@ export const createFor = (
     idx: number,
     anchor: Node = parentAnchor,
   ): ForBlock {
-    const scope = effectScope()
+    const scope = new BlockEffectScope(instance, parentScope)
+
     const [item, key, index] = getItem(source, idx)
     const block: ForBlock = (newBlocks[idx] = {
       nodes: null!, // set later
@@ -239,8 +270,12 @@ export const createFor = (
     const res = scope.run(() => renderItem(block))!
     block.nodes = res[0]
     block.update = res[1]
-    if (getMemo) block.update()
-    if (parent) insert(block.nodes, parent, anchor)
+
+    invokeWithMount(scope, () => {
+      if (getMemo) block.update()
+      if (parent) insert(block.nodes, parent, anchor)
+    })
+
     return block
   }
 
@@ -275,10 +310,13 @@ export const createFor = (
         }
       }
     }
-    if (needsUpdate) {
-      block.s = [newItem, newKey, newIndex]
-      block.update()
-    }
+
+    block.s = [newItem, newKey, newIndex]
+    invokeWithUpdate(block.scope, () => {
+      if (needsUpdate) {
+        block.update()
+      }
+    })
   }
 
   function updateWithoutMemo(
@@ -287,20 +325,24 @@ export const createFor = (
     newKey = block.s[1],
     newIndex = block.s[2],
   ) {
-    if (
+    let needsUpdate =
       newItem !== block.s[0] ||
       newKey !== block.s[1] ||
       newIndex !== block.s[2] ||
       !isReactive(newItem)
-    ) {
-      block.s = [newItem, newKey, newIndex]
-      block.update()
-    }
+
+    block.s = [newItem, newKey, newIndex]
+    invokeWithUpdate(block.scope, () => {
+      if (needsUpdate) {
+        block.update()
+      }
+    })
   }
 
   function unmount({ nodes, scope }: ForBlock) {
-    remove(nodes, parent!)
-    scope.stop()
+    invokeWithUnmount(scope, () => {
+      removeBlock(nodes, parent!)
+    })
   }
 }
 

--- a/packages/runtime-vapor/src/blockEffectScope.ts
+++ b/packages/runtime-vapor/src/blockEffectScope.ts
@@ -1,0 +1,36 @@
+import { EffectScope } from '@vue/reactivity'
+import type { ComponentInternalInstance } from './component'
+import type { DirectiveBindingsMap } from './directives'
+
+export class BlockEffectScope extends EffectScope {
+  /**
+   * instance
+   * @internal
+   */
+  it: ComponentInternalInstance
+  /**
+   * isMounted
+   * @internal
+   */
+  im: boolean
+  /**
+   * directives
+   * @internal
+   */
+  dirs?: DirectiveBindingsMap
+
+  constructor(
+    instance: ComponentInternalInstance,
+    parentScope: EffectScope | null,
+  ) {
+    super(false, parentScope || undefined)
+    this.im = false
+    this.it = instance
+  }
+}
+
+export function isRenderEffectScope(
+  scope: EffectScope | undefined,
+): scope is BlockEffectScope {
+  return scope instanceof BlockEffectScope
+}

--- a/packages/runtime-vapor/src/componentLifecycle.ts
+++ b/packages/runtime-vapor/src/componentLifecycle.ts
@@ -25,7 +25,7 @@ export function invokeLifecycle(
       post ? queuePostFlushCb(fn) : fn()
     }
 
-    invokeDirectiveHook(instance, directive)
+    invokeDirectiveHook(instance, directive, instance.scope)
   }
 
   function invokeSub() {

--- a/packages/runtime-vapor/src/directives.ts
+++ b/packages/runtime-vapor/src/directives.ts
@@ -107,11 +107,10 @@ export function withDirectives<T extends ComponentInternalInstance | Node>(
   const parentScope = getCurrentScope() as BlockEffectScope
 
   if (__DEV__ && !isRenderEffectScope(parentScope)) {
-    warn(`v-directive should be used inside RenderEffectScope`)
+    warn(`Directives should be used inside of RenderEffectScope.`)
   }
 
   const directivesMap = (parentScope.dirs ||= new Map())
-
   if (!(bindings = directivesMap.get(node))) {
     directivesMap.set(node, (bindings = []))
   }

--- a/packages/runtime-vapor/src/directives.ts
+++ b/packages/runtime-vapor/src/directives.ts
@@ -1,32 +1,48 @@
-import { isFunction } from '@vue/shared'
+import { invokeArrayFns, isFunction } from '@vue/shared'
 import {
   type ComponentInternalInstance,
   currentInstance,
   isVaporComponent,
+  setCurrentInstance,
 } from './component'
-import { pauseTracking, resetTracking, traverse } from '@vue/reactivity'
-import { VaporErrorCodes, callWithAsyncErrorHandling } from './errorHandling'
-import { renderEffect } from './renderEffect'
+import {
+  EffectFlags,
+  ReactiveEffect,
+  type SchedulerJob,
+  getCurrentScope,
+  pauseTracking,
+  resetTracking,
+  traverse,
+} from '@vue/reactivity'
+import {
+  VaporErrorCodes,
+  callWithAsyncErrorHandling,
+  callWithErrorHandling,
+} from './errorHandling'
+import { queueJob, queuePostFlushCb } from './scheduler'
 import { warn } from './warning'
+import { type BlockEffectScope, isRenderEffectScope } from './blockEffectScope'
 import { normalizeBlock } from './dom/element'
 
 export type DirectiveModifiers<M extends string = string> = Record<M, boolean>
 
-export interface DirectiveBinding<V = any, M extends string = string> {
+export interface DirectiveBinding<T = any, V = any, M extends string = string> {
   instance: ComponentInternalInstance
   source?: () => V
   value: V
   oldValue: V | null
   arg?: string
   modifiers?: DirectiveModifiers<M>
-  dir: ObjectDirective<any, V>
+  dir: ObjectDirective<T, V, M>
 }
+
+export type DirectiveBindingsMap = Map<Node, DirectiveBinding[]>
 
 export type DirectiveHook<
   T = any | null,
   V = any,
   M extends string = string,
-> = (node: T, binding: DirectiveBinding<V, M>) => void
+> = (node: T, binding: DirectiveBinding<T, V, M>) => void
 
 // create node -> `created` -> node operation -> `beforeMount` -> node mounted -> `mounted`
 // effect update -> `beforeUpdate` -> node updated -> `updated`
@@ -43,7 +59,7 @@ export type ObjectDirective<T = any, V = any, M extends string = string> = {
   [K in DirectiveHookName]?: DirectiveHook<T, V, M> | undefined
 } & {
   /** Watch value deeply */
-  deep?: boolean
+  deep?: boolean | number
 }
 
 export type FunctionDirective<
@@ -86,9 +102,19 @@ export function withDirectives<T extends ComponentInternalInstance | Node>(
     node = nodeOrComponent
   }
 
-  const instance = currentInstance
-  if (!instance.dirs.has(node)) instance.dirs.set(node, [])
-  const bindings = instance.dirs.get(node)!
+  let bindings: DirectiveBinding[]
+  const instance = currentInstance!
+  const parentScope = getCurrentScope() as BlockEffectScope
+
+  if (__DEV__ && !isRenderEffectScope(parentScope)) {
+    warn(`v-directive should be used inside RenderEffectScope`)
+  }
+
+  const directivesMap = (parentScope.dirs ||= new Map())
+
+  if (!(bindings = directivesMap.get(node))) {
+    directivesMap.set(node, (bindings = []))
+  }
 
   for (const directive of directives) {
     let [dir, source, arg, modifiers] = directive
@@ -103,25 +129,38 @@ export function withDirectives<T extends ComponentInternalInstance | Node>(
     const binding: DirectiveBinding = {
       dir,
       instance,
-      source,
       value: null, // set later
       oldValue: undefined,
       arg,
       modifiers,
     }
-    bindings.push(binding)
 
-    callDirectiveHook(node, binding, instance, 'created')
-
-    // register source
     if (source) {
       if (dir.deep) {
         const deep = dir.deep === true ? undefined : dir.deep
         const baseSource = source
         source = () => traverse(baseSource(), deep)
       }
-      renderEffect(source)
+
+      const effect = new ReactiveEffect(() =>
+        callWithErrorHandling(
+          source!,
+          instance,
+          VaporErrorCodes.RENDER_FUNCTION,
+        ),
+      )
+      const triggerRenderingUpdate = createRenderingUpdateTrigger(
+        instance,
+        effect,
+      )
+      effect.scheduler = () => queueJob(triggerRenderingUpdate)
+
+      binding.source = effect.run.bind(effect)
     }
+
+    bindings.push(binding)
+
+    callDirectiveHook(node, binding, instance, 'created')
   }
 
   return nodeOrComponent
@@ -145,13 +184,14 @@ function getComponentNode(component: ComponentInternalInstance) {
 export function invokeDirectiveHook(
   instance: ComponentInternalInstance | null,
   name: DirectiveHookName,
-  nodes?: IterableIterator<Node>,
+  scope: BlockEffectScope,
 ) {
-  if (!instance) return
-  nodes = nodes || instance.dirs.keys()
-  for (const node of nodes) {
-    const directives = instance.dirs.get(node) || []
-    for (const binding of directives) {
+  const { dirs } = scope
+  if (name === 'mounted') scope.im = true
+  if (!dirs) return
+  const iterator = dirs.entries()
+  for (const [node, bindings] of iterator) {
+    for (const binding of bindings) {
       callDirectiveHook(node, binding, instance, name)
     }
   }
@@ -178,4 +218,44 @@ function callDirectiveHook(
     binding,
   ])
   resetTracking()
+}
+
+export function createRenderingUpdateTrigger(
+  instance: ComponentInternalInstance,
+  effect: ReactiveEffect,
+): SchedulerJob {
+  job.id = instance.uid
+  return job
+  function job() {
+    if (!(effect.flags & EffectFlags.ACTIVE) || !effect.dirty) {
+      return
+    }
+
+    if (instance.isMounted && !instance.isUpdating) {
+      instance.isUpdating = true
+      const reset = setCurrentInstance(instance)
+
+      const { bu, u, scope } = instance
+      const { dirs } = scope
+      // beforeUpdate hook
+      if (bu) {
+        invokeArrayFns(bu)
+      }
+      invokeDirectiveHook(instance, 'beforeUpdate', scope)
+
+      queuePostFlushCb(() => {
+        instance.isUpdating = false
+        const reset = setCurrentInstance(instance)
+        if (dirs) {
+          invokeDirectiveHook(instance, 'updated', scope)
+        }
+        // updated hook
+        if (u) {
+          queuePostFlushCb(u)
+        }
+        reset()
+      })
+      reset()
+    }
+  }
 }

--- a/packages/runtime-vapor/src/directivesChildFragment.ts
+++ b/packages/runtime-vapor/src/directivesChildFragment.ts
@@ -1,0 +1,152 @@
+import { ReactiveEffect, getCurrentScope } from '@vue/reactivity'
+import {
+  type Directive,
+  type DirectiveHookName,
+  createRenderingUpdateTrigger,
+  invokeDirectiveHook,
+} from './directives'
+import { warn } from './warning'
+import { type BlockEffectScope, isRenderEffectScope } from './blockEffectScope'
+import { currentInstance } from './component'
+import { VaporErrorCodes, callWithErrorHandling } from './errorHandling'
+import { queueJob, queuePostFlushCb } from './scheduler'
+
+/**
+ * used in createIf and createFor
+ * manages Directives of child fragments in the component dom.
+ */
+export function createChildFragmentDirectives(
+  anchor: Node,
+  getScopes: () => BlockEffectScope[],
+  source: () => any,
+  initCallback: (getValue: () => any) => void,
+  effectCallback: (getValue: () => any) => void,
+  once?: boolean,
+) {
+  let isTriggered = false
+  const instance = currentInstance!
+  const parentScope = getCurrentScope() as BlockEffectScope
+  if (__DEV__) {
+    if (!isRenderEffectScope(parentScope)) {
+      warn('child directives can only be added to a render effect scope')
+    }
+    if (!instance) {
+      warn('child directives can only be added in a component')
+    }
+  }
+
+  const callSourceWithErrorHandling = () =>
+    callWithErrorHandling(source, instance, VaporErrorCodes.RENDER_FUNCTION)
+
+  if (once) {
+    initCallback(callSourceWithErrorHandling)
+    return
+  }
+
+  const directiveBindingsMap = (parentScope.dirs ||= new Map())
+  const dir: Directive = {
+    beforeUpdate: onDirectiveBeforeUpdate,
+    beforeMount: () => invokeChildrenDirectives('beforeMount'),
+    mounted: () => invokeChildrenDirectives('mounted'),
+    beforeUnmount: () => invokeChildrenDirectives('beforeUnmount'),
+    unmounted: () => invokeChildrenDirectives('unmounted'),
+  }
+  directiveBindingsMap.set(anchor, [
+    {
+      dir,
+      instance,
+      value: null,
+      oldValue: undefined,
+    },
+  ])
+
+  const effect = new ReactiveEffect(callSourceWithErrorHandling)
+  const triggerRenderingUpdate = createRenderingUpdateTrigger(instance, effect)
+  effect.scheduler = () => {
+    isTriggered = true
+    queueJob(triggerRenderingUpdate)
+  }
+
+  const getValue = () => effect.run()
+
+  initCallback(getValue)
+
+  function onDirectiveBeforeUpdate() {
+    if (isTriggered) {
+      isTriggered = false
+      effectCallback(getValue)
+    } else {
+      const scopes = getScopes()
+      for (const scope of scopes) {
+        invokeWithUpdate(scope)
+      }
+      return
+    }
+  }
+
+  function invokeChildrenDirectives(name: DirectiveHookName) {
+    const scopes = getScopes()
+    for (const scope of scopes) {
+      invokeDirectiveHook(instance, name, scope)
+    }
+  }
+}
+
+export function invokeWithMount(scope: BlockEffectScope, handler?: () => any) {
+  if (isRenderEffectScope(scope.parent) && !scope.parent.im) {
+    return handler && handler()
+  }
+  return invokeWithDirsHooks(scope, 'mount', handler)
+}
+
+export function invokeWithUnmount(
+  scope: BlockEffectScope,
+  handler?: () => void,
+) {
+  try {
+    return invokeWithDirsHooks(scope, 'unmount', handler)
+  } finally {
+    scope.stop()
+  }
+}
+
+export function invokeWithUpdate(
+  scope: BlockEffectScope,
+  handler?: () => void,
+) {
+  return invokeWithDirsHooks(scope, 'update', handler)
+}
+
+const lifecycleMap = {
+  mount: ['beforeMount', 'mounted'],
+  update: ['beforeUpdate', 'updated'],
+  unmount: ['beforeUnmount', 'unmounted'],
+} as const
+
+function invokeWithDirsHooks(
+  scope: BlockEffectScope,
+  name: keyof typeof lifecycleMap,
+  handler?: () => any,
+) {
+  const { dirs, it: instance } = scope
+  const [before, after] = lifecycleMap[name]
+
+  if (!dirs) {
+    const res = handler && handler()
+    if (name === 'mount') {
+      queuePostFlushCb(() => (scope.im = true))
+    }
+    return res
+  }
+
+  invokeDirectiveHook(instance, before, scope)
+  try {
+    if (handler) {
+      return handler()
+    }
+  } finally {
+    queuePostFlushCb(() => {
+      invokeDirectiveHook(instance, after, scope)
+    })
+  }
+}

--- a/packages/runtime-vapor/src/directivesChildFragment.ts
+++ b/packages/runtime-vapor/src/directivesChildFragment.ts
@@ -13,7 +13,7 @@ import { queueJob, queuePostFlushCb } from './scheduler'
 
 /**
  * used in createIf and createFor
- * manages Directives of child fragments in the component dom.
+ * manage directives of child fragments in components.
  */
 export function createChildFragmentDirectives(
   anchor: Node,


### PR DESCRIPTION
### Expected Behavior of Directive Lifecycle within `v-for`

#### Create Item

new item:           `created` -> `beforeMount` -> `mounted`
other everyone: `beforeUpdate` -> `updated`
all events:           `beforeUpdate` -> `created` -> `beforeMount` -> `updated` -> `mounted`

#### Remove Item

removed item:    `beforeUnmount` -> `unmounted`
other everyone: `beforeUpdate` -> `updated`
all events:           `beforeUpdate` -> `beforeUnmount` -> `updated` -> `unmounted`

#### Move Item

everyone: `beforeUpdate` -> `updated`

I've created new `BlockEffectScope` and `createChildFragmentDirectives` APIs that I hope will help make it easier to implement Lifecycle Hooks in Vapor. such as the lifecycle in slots or in components