### PR TITLE
perf: optimize scheduler queueJob performance

### DIFF
--- a/packages/reactivity/src/baseWatch.ts
+++ b/packages/reactivity/src/baseWatch.ts
@@ -36,9 +36,11 @@ export enum BaseWatchErrorCodes {
 // TODO move to a scheduler package
 export interface SchedulerJob extends Function {
   id?: number
+  // TODO refactor these boolean flags to a single bitwise flag
   pre?: boolean
   active?: boolean
   computed?: boolean
+  queued?: boolean
   /**
    * Indicates whether the effect is allowed to recursively trigger itself
    * when managed by the scheduler.


### PR DESCRIPTION
Optimize `queueJob` when queueing large amount of jobs with the same id (common in v-for under vapor mode).

Benchmark for selecting from 10000 items:

- Before 
  - `select: min: 23.30 / max: 29.50 / median: 26.00ms / mean: 26.02ms / time: 24.80ms / std: 2.08 over 10 runs`
- After
  - `select: min: 10.90 / max: 18.50 / median: 15.10ms / mean: 14.41ms / time: 15.20ms / std: 2.47 over 10 runs`
- `vuejs/vapor` (reference)
  - without memo `select: min: 9.60 / max: 27.80 / median: 19.10ms / mean: 16.54ms / std: 5.87 over 10 runs`
  - with memo `select: min: 6.00 / max: 23.30 / median: 8.60ms / mean: 12.58ms / std: 6.51 over 10 runs`