### PR TITLE
fix(playground): type error on vite config plugin option

### DIFF
--- a/playground/plugin-vue.d.ts
+++ b/playground/plugin-vue.d.ts
@@ -1,0 +1,8 @@
+import '@vitejs/plugin-vue'
+
+// TODO: add type to @vitejs/plugin-vue
+declare module '@vitejs/plugin-vue' {
+  export interface Options {
+    vapor?: boolean
+  }
+}


### PR DESCRIPTION
fixed type error

before:
<img width="830" alt="スクリーンショット 2024-02-28 22 59 39" src="https://github.com/vuejs/core-vapor/assets/71201308/b61286b2-89c0-4291-b226-2be5bf604527">

after:
<img width="436" alt="スクリーンショット 2024-02-28 23 00 05" src="https://github.com/vuejs/core-vapor/assets/71201308/57607d50-a544-4b71-bc76-e1c37c4a6107">
