### PR TITLE
perf(runtime-vapor): don't wrap `Array.from` for array in v-for

### DIFF
--- a/packages/runtime-vapor/src/for.ts
+++ b/packages/runtime-vapor/src/for.ts
@@ -321,16 +321,18 @@ export const createFor = (
     source: any,
     idx: number,
   ): [item: any, key: any, index?: number] {
-    if (source && source[Symbol.iterator as any])
-      source = Array.from(source as Iterable<any>)
-
     if (isArray(source) || isString(source)) {
       return [source[idx], idx, undefined]
     } else if (typeof source === 'number') {
       return [idx + 1, idx, undefined]
     } else if (isObject(source)) {
-      const key = Object.keys(source)[idx]
-      return [source[key], key, idx]
+      if (source && source[Symbol.iterator as any]) {
+        source = Array.from(source as Iterable<any>)
+        return [source[idx], idx, undefined]
+      } else {
+        const key = Object.keys(source)[idx]
+        return [source[key], key, idx]
+      }
     }
     return null!
   }


### PR DESCRIPTION
Incorrect `Array.from` causes `v-for` to be very time-consuming at runtime

![v-for performance problems](https://github.com/vuejs/core-vapor/assets/19204772/afaa9c90-7ff4-4f6e-ace3-b3292d31296a)
