### PR TITLE
feat:try to deal with the template abbreviation of end tag

### DIFF
--- a/packages/compiler-vapor/__tests__/__snapshots__/compile.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/__snapshots__/compile.spec.ts.snap
@@ -12,6 +12,16 @@ export function render(_ctx) {
 }"
 `;
 
+exports[`compile > component close tag 1`] = `
+"import { template as _template } from 'vue/vapor';
+const t0 = _template("<div><Comp/></div>")
+
+export function render(_ctx) {
+  const n0 = t0()
+  return n0
+}"
+`;
+
 exports[`compile > custom directive > basic 1`] = `
 "import { children as _children, resolveDirective as _resolveDirective, withDirectives as _withDirectives, template as _template } from 'vue/vapor';
 const t0 = _template("<div></div>")

--- a/packages/compiler-vapor/__tests__/__snapshots__/compile.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/__snapshots__/compile.spec.ts.snap
@@ -130,7 +130,7 @@ export function render(_ctx) {
 
 exports[`compile > directives > v-pre > self-closing v-pre 1`] = `
 "import { children as _children, createTextNode as _createTextNode, append as _append, renderEffect as _renderEffect, setText as _setText, setDynamicProp as _setDynamicProp, template as _template } from 'vue/vapor';
-const t0 = _template("<div></div><div><Comp></Comp></div>")
+const t0 = _template("<div></div><div><Comp/></div>")
 
 export function render(_ctx) {
   const n0 = t0()
@@ -145,7 +145,7 @@ export function render(_ctx) {
 
 exports[`compile > directives > v-pre > should not affect siblings after it 1`] = `
 "import { children as _children, createTextNode as _createTextNode, append as _append, renderEffect as _renderEffect, setText as _setText, setDynamicProp as _setDynamicProp, template as _template } from 'vue/vapor';
-const t0 = _template("<div :id=\\"foo\\"><Comp></Comp>{{ bar }}</div><div><Comp></Comp></div>")
+const t0 = _template("<div :id=\\"foo\\"><Comp></Comp>{{ bar }}</div><div><Comp/></div>")
 
 export function render(_ctx) {
   const n0 = t0()

--- a/packages/compiler-vapor/__tests__/compile.spec.ts
+++ b/packages/compiler-vapor/__tests__/compile.spec.ts
@@ -96,7 +96,7 @@ describe('compile', () => {
         )
 
         expect(code).toMatchSnapshot()
-        expect(code).contains('<div></div><div><Comp></Comp></div>')
+        expect(code).contains('<div></div><div><Comp/></div>')
         // Waiting for TODO, There should be more here.
       })
     })

--- a/packages/compiler-vapor/__tests__/compile.spec.ts
+++ b/packages/compiler-vapor/__tests__/compile.spec.ts
@@ -21,6 +21,11 @@ describe('compile', () => {
     )
     expect(code).matchSnapshot()
   })
+  test('component close tag', () => {
+    const code = compile(`<div><Comp></Comp></div>`)
+    expect(code).matchSnapshot()
+    expect(code).contains(JSON.stringify('<div><Comp/></div>'))
+  })
 
   test('dynamic root', () => {
     const code = compile(`{{ 1 }}{{ 2 }}`)

--- a/packages/compiler-vapor/src/transforms/transformElement.ts
+++ b/packages/compiler-vapor/src/transforms/transformElement.ts
@@ -61,7 +61,11 @@ export const transformElement: NodeTransform = (node, context) => {
 
     // TODO remove unnecessary close tag, e.g. if it's the last element of the template
     if (!isVoidTag(tag)) {
-      context.template += `</${tag}>`
+      if (node.tagType === ElementTypes.COMPONENT) {
+        context.template = `<${tag}/>`
+      } else {
+        context.template += `</${tag}>`
+      }
     }
   }
 }


### PR DESCRIPTION
In #112, I attempted to abbreviate the end tag within the template. I'm not entirely sure about the specific meaning of the end tag. From my perspective, I simply tried to represent `<div></div>` as `<div />`. 
Additionally, I've written some tests to address this situation, `npm run test-unit` seems ok.hoping it can be of assistance. Should there be any issues with this approach, I will close my pull request. Thank you.