### PR TITLE
fix(compiler-vapor): SET_REF operation should be registered last

### DIFF
--- a/packages/compiler-vapor/src/transforms/transformRef.ts
+++ b/packages/compiler-vapor/src/transforms/transformRef.ts
@@ -22,11 +22,10 @@ export const transformRef: NodeTransform = (node, context) => {
       ? createSimpleExpression(dir.value.content, true, dir.value.loc)
       : EMPTY_EXPRESSION
   }
-  return () => {
+  return () =>
     context.registerOperation({
       type: IRNodeTypes.SET_REF,
       element: context.reference(),
       value,
     })
-  }
 }

--- a/packages/compiler-vapor/src/transforms/transformRef.ts
+++ b/packages/compiler-vapor/src/transforms/transformRef.ts
@@ -22,10 +22,11 @@ export const transformRef: NodeTransform = (node, context) => {
       ? createSimpleExpression(dir.value.content, true, dir.value.loc)
       : EMPTY_EXPRESSION
   }
-
-  context.registerOperation({
-    type: IRNodeTypes.SET_REF,
-    element: context.reference(),
-    value,
-  })
+  return () => {
+    context.registerOperation({
+      type: IRNodeTypes.SET_REF,
+      element: context.reference(),
+      value,
+    })
+  }
 }


### PR DESCRIPTION
Currently, ref with the component will cause `setRef` to be called first, resulting in an error.

![image](https://github.com/vuejs/core-vapor/assets/25676701/f1c2e2e6-b3d0-49ca-a741-111a4003d46a)


![image](https://github.com/vuejs/core-vapor/assets/25676701/a9540edc-da0c-4962-b5e5-ee81d996c118)

