### PR TITLE
fix(runtime-vapor): the effect being collected in the wrong scope

### DIFF
--- a/packages/runtime-vapor/src/renderEffect.ts
+++ b/packages/runtime-vapor/src/renderEffect.ts
@@ -43,9 +43,8 @@ export function renderEffect(cb: () => void) {
       effect.run()
     }
   }
-
+  const reset = instance && setCurrentInstance(instance)
   effect = new ReactiveEffect(() => {
-    const reset = instance && setCurrentInstance(instance)
     callWithAsyncErrorHandling(cb, instance, VaporErrorCodes.RENDER_FUNCTION)
     reset?.()
   })


### PR DESCRIPTION
See [this](https://vapor-repl.netlify.app/#__VAPOR__eNp9UsGOmzAQ/ZWReyCRKKjdniJI1a5y2B7aqq16qXsgMBA2YFv2wGaF+PeOYcPSqlpLSPabN89vnhnEB2OivkOxE4nLbW0IHFJn9lLVrdGWYACLZQgV0m1nLSq6U44ylWMIDxnlp0NZYk4wQml1CwFrBVJJlWumQesqSL3AJnjz9ibYSpXE8zV8AR8IW9NkhHwCSGplOoL+dasLbFIpuFsKiOeitwS8GIwaVBWdIE1TSI77YfDg+ys6jkl8nHviuWnp/ZUcWb7UlsU3fXjegi59L9+yO+Mjo2feesGeZUKv8/tZKIlXdkUoalXgJTpR26zSo0eD3rouugaleLrYryXP3CJr/Mz4yOmvk4t7D3J+//R42kyK4qcHW5H+1tvwt41a3SnaBK8yY4LtknlS1D3UBftjnM0lMQN7HoUcv1dZV9G904qnGby6FLluTd2g/WKo5veUYgdTxdeyptEPnyaMbIfhFc9PmJ//g9+7i8ek+GrRoe05nKVGmeX/ay4fvn/GC++X4jXKF4rf0Omm8x5n2sdOFWx7xZvc3k1p1qr64Q4XQuWuQ3mjnjlOfCk439sXRn+2exO9m/qkGsX4BwduEjg=), delete input box content, `msg.length === 3` not updated, because the constructor of ReactiveEffect is run before `scope.on`.