### PR TITLE
fix(runtime-vapor): detach effect scope & component instance

### DIFF
--- a/packages/runtime-vapor/__tests__/dom/prop.spec.ts
+++ b/packages/runtime-vapor/__tests__/dom/prop.spec.ts
@@ -14,13 +14,16 @@ import {
   setCurrentInstance,
 } from '../../src/component'
 import { getMetadata, recordPropMetadata } from '../../src/componentMetadata'
+import { getCurrentScope } from '@vue/reactivity'
 
 let removeComponentInstance = NOOP
 beforeEach(() => {
   const instance = createComponentInstance((() => {}) as any, {})
   const reset = setCurrentInstance(instance)
+  const prev = getCurrentScope()
   instance.scope.on()
   removeComponentInstance = () => {
+    instance.scope.prevScope = prev
     instance.scope.off()
     reset()
     removeComponentInstance = NOOP

--- a/packages/runtime-vapor/__tests__/dom/prop.spec.ts
+++ b/packages/runtime-vapor/__tests__/dom/prop.spec.ts
@@ -17,10 +17,11 @@ import { getMetadata, recordPropMetadata } from '../../src/componentMetadata'
 
 let removeComponentInstance = NOOP
 beforeEach(() => {
-  const reset = setCurrentInstance(
-    createComponentInstance((() => {}) as any, {}),
-  )
+  const instance = createComponentInstance((() => {}) as any, {})
+  const reset = setCurrentInstance(instance)
+  instance.scope.on()
   removeComponentInstance = () => {
+    instance.scope.off()
     reset()
     removeComponentInstance = NOOP
   }

--- a/packages/runtime-vapor/src/apiLifecycle.ts
+++ b/packages/runtime-vapor/src/apiLifecycle.ts
@@ -39,7 +39,9 @@ const injectHook = (
         }
         pauseTracking()
         const reset = setCurrentInstance(target)
-        const res = callWithAsyncErrorHandling(hook, target, type, args)
+        const res = target.scope.run(() =>
+          callWithAsyncErrorHandling(hook, target, type, args),
+        )
         reset()
         resetTracking()
         return res

--- a/packages/runtime-vapor/src/apiRender.ts
+++ b/packages/runtime-vapor/src/apiRender.ts
@@ -64,7 +64,9 @@ export function setupComponent(
       instance.setupState = proxyRefs(stateOrNode)
     }
     if (!block && component.render) {
+      pauseTracking()
       block = component.render(instance.setupState)
+      resetTracking()
     }
 
     if (block instanceof DocumentFragment) {

--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -182,9 +182,7 @@ export const getCurrentInstance: () => ComponentInternalInstance | null = () =>
 export const setCurrentInstance = (instance: ComponentInternalInstance) => {
   const prev = currentInstance
   currentInstance = instance
-  instance.scope.on()
   return () => {
-    instance.scope.off()
     currentInstance = prev
   }
 }

--- a/packages/runtime-vapor/src/componentLifecycle.ts
+++ b/packages/runtime-vapor/src/componentLifecycle.ts
@@ -17,7 +17,9 @@ export function invokeLifecycle(
     if (hooks) {
       const fn = () => {
         const reset = setCurrentInstance(instance)
-        invokeArrayFns(hooks)
+        instance.scope.run(() => {
+          invokeArrayFns(hooks)
+        })
         reset()
       }
       post ? queuePostRenderEffect(fn) : fn()

--- a/packages/runtime-vapor/src/componentLifecycle.ts
+++ b/packages/runtime-vapor/src/componentLifecycle.ts
@@ -17,9 +17,7 @@ export function invokeLifecycle(
     if (hooks) {
       const fn = () => {
         const reset = setCurrentInstance(instance)
-        instance.scope.run(() => {
-          invokeArrayFns(hooks)
-        })
+        instance.scope.run(() => invokeArrayFns(hooks))
         reset()
       }
       post ? queuePostRenderEffect(fn) : fn()

--- a/packages/runtime-vapor/src/componentProps.ts
+++ b/packages/runtime-vapor/src/componentProps.ts
@@ -212,7 +212,9 @@ function resolvePropValue(
         //   value = propsDefaults[key]
         // } else {
         const reset = setCurrentInstance(instance)
-        value = defaultValue.call(null, props)
+        instance.scope.run(() => {
+          value = defaultValue.call(null, props)
+        })
         reset()
         // }
       } else {

--- a/packages/runtime-vapor/src/componentProps.ts
+++ b/packages/runtime-vapor/src/componentProps.ts
@@ -212,9 +212,7 @@ function resolvePropValue(
         //   value = propsDefaults[key]
         // } else {
         const reset = setCurrentInstance(instance)
-        instance.scope.run(() => {
-          value = defaultValue.call(null, props)
-        })
+        instance.scope.run(() => (value = defaultValue.call(null, props)))
         reset()
         // }
       } else {


### PR DESCRIPTION
The existing `setCurrentInstance` will set `instance.scope.on()` internally and `instance.scope.off()` when calling reset, but as an internal Function, this hidden behavior is not very intuitive, and there are two problems:

1. `effectScope.on` cannot handle nested recursive calls to itself, because the internal `prevScope` can only store one value.
2. Not all situations that need to set `currentInstance` need to set `instance.scope.on()` at the same time, and this behavior is wrong in `renderEffect`.

So this PR removes `instance.scope.on()` in `setCurrentInstance`.

I initially started investigating this issue because of the following bug.

[Bug Playground](https://vapor-repl.netlify.app/#__VAPOR__eNp9UcFu1DAQ/ZWROXhX2iaq4LRKgwD1AAdAgLhgDiGZJC6ObdlOWBTl3xk77DatqkaKZL/3ZvzmzczeWJtNI7IjK3ztpA3gMYy2FFoO1rgAMzhsYYHWmQE4SbnQtdE+wOA7uInsjveolOF7oYt87UL1dAk4WFUFpBtAIbUdA0xXg2lQ3QhG9YJBvpLxRaDvR+FtpUnVGkea3XSQezBtfEywsvhVzjNMsCxFno4SikhlCnUX+qtreA38wI+cJ0lsVf5M/fP1gaK/pjKqiDSdo+ONS3ZgUjd4yvowqE0m4a/F6Ng0o0LysXqN3yWl2iH1+F7RlTLdBpZPEaTYHtVE2SrK8v9r2Ige9tvRv88GM+qw4y8qa/n+EnXRyAlkQ/4IjyHlBJQ0SvC0qFZ22Z03mqaZY3fBajNYqdB9skHSIgU7QmIiV9Ee/3xIWHAjHs543WP9+wn8zp8iJthnhx7dROFcuFC5DsNK3379iCc6X8hzlM+QX9AbNUaPq+ztqBuyvdElt+9TmlJ33/ztKaD256Gi0ahckl4wyvfdM6Pf232ZvUp1Qi9s+QeIPARv)

In this example, try entering text.

There won't be any problem if just adding texts, once the the pe-existing texts get deleted, it will cause the call to`setText` to fail.
This is because when the `v-for` element get unmounted, the `effect.onStop()` that does not belong to the `v-for` element would be mistakenly called. This is caused by the combined problems with problem "1" and "2" mentioned above.

