### PR TITLE
perf(compiler-core):template abbreviation of end tag

### DIFF
--- a/packages/compiler-core/__tests__/__snapshots__/parse.spec.ts.snap
+++ b/packages/compiler-core/__tests__/__snapshots__/parse.spec.ts.snap
@@ -2399,6 +2399,7 @@ exports[`compiler: parse > Errors > MISSING_END_TAG_NAME > <template></></templa
     {
       "children": [],
       "codegenNode": undefined,
+      "isShouldSelfClosing": true,
       "loc": {
         "end": {
           "column": 25,
@@ -4549,6 +4550,7 @@ exports[`compiler: parse > Errors > X_MISSING_END_TAG > <template><div></templat
         },
       ],
       "codegenNode": undefined,
+      "isShouldSelfClosing": true,
       "loc": {
         "end": {
           "column": 27,

--- a/packages/compiler-core/__tests__/parse.spec.ts
+++ b/packages/compiler-core/__tests__/parse.spec.ts
@@ -476,6 +476,7 @@ describe('compiler: parse', () => {
         type: NodeTypes.ELEMENT,
         ns: Namespaces.HTML,
         tag: 'div',
+        isShouldSelfClosing: true,
         tagType: ElementTypes.ELEMENT,
         codegenNode: undefined,
         props: [],

--- a/packages/compiler-core/src/ast.ts
+++ b/packages/compiler-core/src/ast.ts
@@ -70,6 +70,7 @@ export enum ElementTypes {
 export interface Node {
   type: NodeTypes
   loc: SourceLocation
+  isShouldSelfClosing?: boolean
 }
 
 // The node's range. The `start` is inclusive and `end` is exclusive.

--- a/packages/compiler-core/src/parser.ts
+++ b/packages/compiler-core/src/parser.ts
@@ -151,7 +151,7 @@ const tokenizer = new Tokenizer(stack, {
     endOpenTag(end)
   },
 
-  onclosetag(start, end) {
+  onclosetag(start, end, isLastElement) {
     const name = getSlice(start, end)
     if (!currentOptions.isVoidTag(name)) {
       let found = false
@@ -159,6 +159,9 @@ const tokenizer = new Tokenizer(stack, {
         const e = stack[i]
         if (e.tag.toLowerCase() === name.toLowerCase()) {
           found = true
+          if (isLastElement) {
+            e.isShouldSelfClosing = true
+          }
           if (i > 0) {
             emitError(ErrorCodes.X_MISSING_END_TAG, stack[0].loc.start.offset)
           }

--- a/packages/compiler-vapor/__tests__/__snapshots__/compile.spec.ts.snap
+++ b/packages/compiler-vapor/__tests__/__snapshots__/compile.spec.ts.snap
@@ -11,6 +11,16 @@ export function render(_ctx) {
 }"
 `;
 
+exports[`compile > close tag 1`] = `
+"import { template as _template } from 'vue/vapor';
+const t0 = _template("<div><span><div /></span></div>")
+
+export function render(_ctx) {
+  const n0 = t0()
+  return n0
+}"
+`;
+
 exports[`compile > custom directive > basic 1`] = `
 "import { resolveDirective as _resolveDirective, withDirectives as _withDirectives, template as _template } from 'vue/vapor';
 const t0 = _template("<div></div>")
@@ -200,6 +210,26 @@ export function render(_ctx) {
 exports[`compile > static template 1`] = `
 "import { template as _template } from 'vue/vapor';
 const t0 = _template("<div><p>hello</p><input><span></span></div>")
+
+export function render(_ctx) {
+  const n0 = t0()
+  return n0
+}"
+`;
+
+exports[`compile > two close tag  1`] = `
+"import { template as _template } from 'vue/vapor';
+const t0 = _template("<div><span /><span /></div>")
+
+export function render(_ctx) {
+  const n0 = t0()
+  return n0
+}"
+`;
+
+exports[`compile > two close tag with text 1`] = `
+"import { template as _template } from 'vue/vapor';
+const t0 = _template("<div><span>ddd</span><span /></div>")
 
 export function render(_ctx) {
   const n0 = t0()

--- a/packages/compiler-vapor/__tests__/abbreviation.spec.ts
+++ b/packages/compiler-vapor/__tests__/abbreviation.spec.ts
@@ -1,15 +1,32 @@
+/*
+ * @Date: 2024-04-21 15:29:37
+ * @Description:
+ */
 /**
  * @vitest-environment jsdom
  */
-
+import {
+  compile as _compile,
+  transformChildren,
+  transformElement,
+  transformText,
+} from '../src'
+import { makeCompile } from './transforms/_utils'
 const parser = new DOMParser()
 
 function parseHTML(html: string) {
   return parser.parseFromString(html, 'text/html').body.innerHTML
 }
 
+const compileWithElementTransform = makeCompile({
+  nodeTransforms: [transformElement, transformChildren, transformText],
+})
+
 function checkAbbr(template: string, abbrevation: string, expected: string) {
   // TODO do some optimzations to make sure template === abbrevation
+  const { ir } = compileWithElementTransform(template)
+  const templateOfIr = ir.template
+  abbrevation = templateOfIr.reduce((cur, next) => cur + next)
   expect(parseHTML(abbrevation)).toBe(expected)
 }
 

--- a/packages/compiler-vapor/__tests__/compile.spec.ts
+++ b/packages/compiler-vapor/__tests__/compile.spec.ts
@@ -22,6 +22,23 @@ describe('compile', () => {
     expect(code).matchSnapshot()
   })
 
+  test('close tag', () => {
+    const code = compile(`<div><span><div></div></span></div>`)
+    expect(code).matchSnapshot()
+    expect(code).contains(JSON.stringify('<div><span><div /></span></div>'))
+  })
+  test('two close tag ', () => {
+    const code = compile(`<div><span></span><span></span></div>`)
+    expect(code).matchSnapshot()
+    expect(code).contains(JSON.stringify('<div><span /><span /></div>'))
+  })
+
+  test('two close tag with text', () => {
+    const code = compile(`<div><span>ddd</span><span></span></div>`)
+    expect(code).matchSnapshot()
+    expect(code).contains(JSON.stringify('<div><span>ddd</span><span /></div>'))
+  })
+
   test('dynamic root', () => {
     const code = compile(`{{ 1 }}{{ 2 }}`)
     expect(code).matchSnapshot()

--- a/packages/compiler-vapor/src/transforms/transformElement.ts
+++ b/packages/compiler-vapor/src/transforms/transformElement.ts
@@ -159,11 +159,21 @@ function transformNativeElement(
       }
     }
   }
+  const { node } = context
 
-  template += `>` + context.childrenTemplate.join('')
+  if (node.isShouldSelfClosing) {
+    template += context.childrenTemplate.join('')
+  } else {
+    template += `>` + context.childrenTemplate.join('')
+  }
+
   // TODO remove unnecessary close tag, e.g. if it's the last element of the template
   if (!isVoidTag(tag)) {
-    template += `</${tag}>`
+    if (node.isShouldSelfClosing) {
+      template += ` />`
+    } else {
+      template += `</${tag}>`
+    }
   }
 
   if (


### PR DESCRIPTION
related:#166
I've made some optimizations to ensure  'abbreviation'  equals 'expected' through the IR, and added the 'isShouldSelfClosing' tag to the Node type. I'm not entirely sure it's correct, but it seems to work🧐