### PR TITLE
refactor(runtime-vapor): remove optional chaining syntax

### DIFF
--- a/packages/runtime-vapor/src/component.ts
+++ b/packages/runtime-vapor/src/component.ts
@@ -249,7 +249,7 @@ export const setCurrentInstance = (instance: ComponentInternalInstance) => {
 }
 
 export const unsetCurrentInstance = () => {
-  currentInstance?.scope.off()
+  currentInstance && currentInstance.scope.off()
   currentInstance = null
 }
 

--- a/packages/runtime-vapor/src/componentSlots.ts
+++ b/packages/runtime-vapor/src/componentSlots.ts
@@ -86,7 +86,9 @@ export function initSlots(
       for (const key in dynamicSlotKeys) {
         if (
           !_dynamicSlots.some(slot =>
-            isArray(slot) ? slot.some(s => s.name === key) : slot?.name === key,
+            slot && isArray(slot)
+              ? slot.some(s => s.name === key)
+              : slot.name === key,
           )
         ) {
           delete slots[key]

--- a/packages/runtime-vapor/src/renderEffect.ts
+++ b/packages/runtime-vapor/src/renderEffect.ts
@@ -25,7 +25,7 @@ export function renderEffect(cb: () => void) {
       return
     }
 
-    if (instance?.isMounted && !instance.isUpdating) {
+    if (instance && instance.isMounted && !instance.isUpdating) {
       instance.isUpdating = true
 
       const { bu, u, dirs } = instance
@@ -76,11 +76,11 @@ export function renderEffect(cb: () => void) {
     if (instance) job.id = instance.uid
     queueJob(job)
   }
-  if (__DEV__) {
-    effect.onTrack = instance?.rtc
+  if (__DEV__ && instance) {
+    effect.onTrack = instance.rtc
       ? e => invokeArrayFns(instance.rtc!, e)
       : void 0
-    effect.onTrigger = instance?.rtg
+    effect.onTrigger = instance.rtg
       ? e => invokeArrayFns(instance.rtg!, e)
       : void 0
   }

--- a/packages/runtime-vapor/src/scheduler.ts
+++ b/packages/runtime-vapor/src/scheduler.ts
@@ -33,13 +33,14 @@ const resolvedPromise = /*#__PURE__*/ Promise.resolve() as Promise<any>
 let currentFlushPromise: Promise<void> | null = null
 
 export function queueJob(job: SchedulerJob) {
+  let lastOne: SchedulerJob | undefined
   if (!(job.flags! & SchedulerJobFlags.QUEUED)) {
     if (job.id == null) {
       queue.push(job)
     } else if (
       // fast path when the job id is larger than the tail
       !(job.flags! & SchedulerJobFlags.PRE) &&
-      job.id >= (queue[queue.length - 1]?.id || 0)
+      job.id >= (((lastOne = queue[queue.length - 1]) && lastOne.id) || 0)
     ) {
       queue.push(job)
     } else {

--- a/packages/runtime-vapor/src/warning.ts
+++ b/packages/runtime-vapor/src/warning.ts
@@ -30,7 +30,10 @@ export function warn(msg: string, ...args: any[]) {
       instance,
       VaporErrorCodes.APP_WARN_HANDLER,
       [
-        msg + args.map(a => a.toString?.() ?? JSON.stringify(a)).join(''),
+        msg +
+          args
+            .map(a => (a.toString && a.toString()) ?? JSON.stringify(a))
+            .join(''),
         instance,
         trace
           .map(


### PR DESCRIPTION
the [optional chaining (?.)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) has [bigger bundle size](https://esbuild.github.io/try/#dAAwLjIxLjEALS10YXJnZXQ9ZXMyMDE5AGE/LmI/LmM)

<img width="595" alt="image" src="https://github.com/vuejs/core-vapor/assets/19204772/e848b2bd-6568-4639-a758-b8876ba235f8">
