### PR TITLE
fix(runtime-vapor): current instance is not attached to static slots

### DIFF
--- a/packages/runtime-vapor/__tests__/componentSlots.spec.ts
+++ b/packages/runtime-vapor/__tests__/componentSlots.spec.ts
@@ -158,6 +158,40 @@ describe('component: slots', () => {
 
   test('the current instance should be kept in the slot', async () => {
     let instanceInDefaultSlot: any
+    let instanceInFooSlot: any
+
+    const Comp = defineComponent({
+      render() {
+        const instance = getCurrentInstance()
+        instance!.slots.default!()
+        instance!.slots.foo!()
+        return template('<div></div>')()
+      },
+    })
+
+    const { instance } = define({
+      render() {
+        return createComponent(Comp, {}, [
+          {
+            default: () => {
+              instanceInDefaultSlot = getCurrentInstance()
+              return template('content')()
+            },
+            foo: () => {
+              instanceInFooSlot = getCurrentInstance()
+              return template('content')()
+            },
+          },
+        ])
+      },
+    }).render()
+
+    expect(instanceInDefaultSlot).toBe(instance)
+    expect(instanceInFooSlot).toBe(instance)
+  })
+
+  test('the current instance should be kept in the dynamic slots', async () => {
+    let instanceInDefaultSlot: any
     let instanceInVForSlot: any
     let instanceInVIfSlot: any
 

--- a/packages/runtime-vapor/src/componentSlots.ts
+++ b/packages/runtime-vapor/src/componentSlots.ts
@@ -40,12 +40,21 @@ export function initSlots(
   if (!rawSlots) return
   if (!isArray(rawSlots)) rawSlots = [rawSlots]
 
-  if (rawSlots.length === 1 && !isDynamicSlotFn(rawSlots[0])) {
-    instance.slots = rawSlots[0]
+  const hasDynamicSlots = rawSlots.length > 1 || isDynamicSlotFn(rawSlots[0])
+
+  const resolved: StaticSlots = (instance.slots = hasDynamicSlots
+    ? shallowReactive({})
+    : {})
+
+  if (!hasDynamicSlots) {
+    // with ctx
+    const slots = rawSlots[0] as StaticSlots
+    for (const name in slots) {
+      registerSlot(name, slots[name])
+    }
     return
   }
 
-  const resolved: StaticSlots = (instance.slots = shallowReactive({}))
   const keys: Set<string>[] = []
   rawSlots.forEach((slots, index) => {
     const isDynamicSlot = isDynamicSlotFn(slots)

--- a/packages/runtime-vapor/src/componentSlots.ts
+++ b/packages/runtime-vapor/src/componentSlots.ts
@@ -40,8 +40,7 @@ export function initSlots(
   if (!rawSlots) return
   if (!isArray(rawSlots)) rawSlots = [rawSlots]
 
-  const hasDynamicSlot = rawSlots.some(slot => isDynamicSlotFn(slot))
-  if (!hasDynamicSlot) {
+  if (!rawSlots.some(slot => isDynamicSlotFn(slot))) {
     instance.slots = {}
     // with ctx
     const slots = rawSlots[0] as StaticSlots
@@ -51,7 +50,7 @@ export function initSlots(
     return
   }
 
-  const resolved: StaticSlots = (instance.slots = shallowReactive({}))
+  instance.slots = shallowReactive({})
   const keys: Set<string>[] = []
   rawSlots.forEach((slots, index) => {
     const isDynamicSlot = isDynamicSlotFn(slots)
@@ -77,7 +76,7 @@ export function initSlots(
               : dynamicSlot && dynamicSlot.name === name)
           ) {
             recordNames.delete(name)
-            delete resolved[name]
+            delete instance.slots[name]
           }
         }
       })
@@ -89,7 +88,7 @@ export function initSlots(
   })
 
   function registerSlot(name: string, fn: Slot, recordNames?: Set<string>) {
-    resolved[name] = withCtx(fn)
+    instance.slots[name] = withCtx(fn)
     recordNames && recordNames.add(name)
   }
 

--- a/packages/runtime-vapor/src/componentSlots.ts
+++ b/packages/runtime-vapor/src/componentSlots.ts
@@ -40,13 +40,9 @@ export function initSlots(
   if (!rawSlots) return
   if (!isArray(rawSlots)) rawSlots = [rawSlots]
 
-  const hasDynamicSlots = rawSlots.length > 1 || isDynamicSlotFn(rawSlots[0])
-
-  const resolved: StaticSlots = (instance.slots = hasDynamicSlots
-    ? shallowReactive({})
-    : {})
-
-  if (!hasDynamicSlots) {
+  const hasDynamicSlot = rawSlots.some(slot => isDynamicSlotFn(slot))
+  if (!hasDynamicSlot) {
+    instance.slots = {}
     // with ctx
     const slots = rawSlots[0] as StaticSlots
     for (const name in slots) {
@@ -55,6 +51,7 @@ export function initSlots(
     return
   }
 
+  const resolved: StaticSlots = (instance.slots = shallowReactive({}))
   const keys: Set<string>[] = []
   rawSlots.forEach((slots, index) => {
     const isDynamicSlot = isDynamicSlotFn(slots)


### PR DESCRIPTION
related #168

When all slots are static slots, it is also necessary to call `withCtx` to attach the current instance to the slots.