### PR TITLE
perf(runtime-vapor): `children` helper

### DIFF
--- a/packages/runtime-vapor/src/dom/template.ts
+++ b/packages/runtime-vapor/src/dom/template.ts
@@ -13,8 +13,8 @@ export function template(html: string) {
 /*! #__NO_SIDE_EFFECTS__ */
 export function children(node: Node, ...paths: number[]): Node {
   for (const idx of paths) {
-    // In different situations, choose the fastest plan
-    // see https://github.com/vuejs/core-vapor/pull/263
+    // In various situations, select the quickest approach.
+    // See https://github.com/vuejs/core-vapor/pull/263
     switch (idx) {
       case 0:
         node = node.firstChild!

--- a/packages/runtime-vapor/src/dom/template.ts
+++ b/packages/runtime-vapor/src/dom/template.ts
@@ -13,8 +13,16 @@ export function template(html: string) {
 /*! #__NO_SIDE_EFFECTS__ */
 export function children(node: Node, ...paths: number[]): Node {
   for (const idx of paths) {
-    for (let i = 0; i <= idx; i++) {
-      node = node[i === 0 ? 'firstChild' : 'nextSibling']!
+    switch (idx) {
+      case 0:
+        node = node.firstChild!
+        break
+      case 1:
+        node = node.firstChild!.nextSibling!
+        break
+      default:
+        node = node.childNodes[idx]
+        break
     }
   }
   return node

--- a/packages/runtime-vapor/src/dom/template.ts
+++ b/packages/runtime-vapor/src/dom/template.ts
@@ -15,17 +15,12 @@ export function children(node: Node, ...paths: number[]): Node {
   for (const idx of paths) {
     // In various situations, select the quickest approach.
     // See https://github.com/vuejs/core-vapor/pull/263
-    switch (idx) {
-      case 0:
-        node = node.firstChild!
-        break
-      case 1:
-        node = node.firstChild!.nextSibling!
-        break
-      default:
-        node = node.childNodes[idx]
-        break
-    }
+    node =
+      idx === 0
+        ? node.firstChild!
+        : idx === 1
+          ? node.firstChild!.nextSibling!
+          : node.childNodes[idx]
   }
   return node
 }

--- a/packages/runtime-vapor/src/dom/template.ts
+++ b/packages/runtime-vapor/src/dom/template.ts
@@ -13,6 +13,8 @@ export function template(html: string) {
 /*! #__NO_SIDE_EFFECTS__ */
 export function children(node: Node, ...paths: number[]): Node {
   for (const idx of paths) {
+    // In different situations, choose the fastest plan
+    // see https://github.com/vuejs/core-vapor/pull/263
     switch (idx) {
       case 0:
         node = node.firstChild!


### PR DESCRIPTION
[Check the Bench](https://jsbench.me/45lyjycdiu/1)

![image](https://github.com/user-attachments/assets/05a0831a-e084-485b-b495-b40e58688c5a)


The old plan (for nextSibling) only has a speed advantage when accessing adjacent elements

<img width="250px" src="https://github.com/user-attachments/assets/1ccfbc9c-836c-4570-b57d-31c52efe195a" />
<img width="250px" src="https://github.com/user-attachments/assets/16b39ec9-2149-4865-bf8f-11b034b6e0cb" />
<img width="250px" src="https://github.com/user-attachments/assets/634192f5-ca6d-47ca-880b-d1b702232345" />
