### PR TITLE
ci: continuous releases with pkg.pr.new

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,10 +64,6 @@ jobs:
   release:
     concurrency:
       group: release
-    if: |
-      github.repository == 'vuejs/core-vapor' &&
-      github.event_name == 'push' &&
-      !contains(github.event.head_commit.message, 'skip release')
     runs-on: ubuntu-latest
     needs: [unit-test, lint-and-test-dts]
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,10 +88,9 @@ jobs:
 
       - run: pnpm install
 
-      - run: pnpm release --vapor --skipTests --tag ${{ github.ref == 'refs/heads/main' && 'latest' || 'branch' }}
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NPM_CONFIG_PROVENANCE: 'true'
+      - run: pnpm build
+
+      - run: pnpm dlx pkg-pr-new@0.0 './packages/*' --template './playground'
 
   # benchmarks:
   #   runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,9 +84,11 @@ jobs:
 
       - run: pnpm install
 
-      - run: pnpm build
+      - name: Build
+        run: pnpm build --withTypes
 
-      - run: pnpm dlx pkg-pr-new@0.0 publish './packages/*' --template './playground' --pnpm
+      - name: Publish
+        run: pnpm dlx pkg-pr-new@0.0 publish './packages/*' --template './playground' --pnpm
 
   # benchmarks:
   #   runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
 
       - run: pnpm build
 
-      - run: pnpm dlx pkg-pr-new@0.0 './packages/*' --template './playground'
+      - run: pnpm dlx pkg-pr-new@0.0 publish './packages/*' --template './playground'
 
   # benchmarks:
   #   runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
 
       - run: pnpm build
 
-      - run: pnpm dlx pkg-pr-new@0.0 publish './packages/*' --template './playground'
+      - run: pnpm dlx pkg-pr-new@0.0 publish './packages/*' --template './playground' --pnpm
 
   # benchmarks:
   #   runs-on: ubuntu-latest


### PR DESCRIPTION
I didn't remove the release file completely, for now let's just see if this works by just adding pkg.pr.new! 

Before running the workflows for this PR, the [github app](https://github.com/apps/pkg-pr-new) should be installed! 

Thank you so much @sxzz for the opportunity! 