### PR TITLE
feat(compiler-vapor): support v-slots expression for jsx-vapor

### DIFF
--- a/packages/compiler-vapor/src/generators/component.ts
+++ b/packages/compiler-vapor/src/generators/component.ts
@@ -163,7 +163,9 @@ function genRawSlots(slots: IRSlots[], context: CodegenContext) {
     ...slots.map(slot =>
       slot.slotType === IRSlotType.STATIC
         ? genStaticSlots(slot, context)
-        : genDynamicSlot(slot, context, true),
+        : slot.slotType === IRSlotType.EXPRESSION
+          ? slot.slots.content
+          : genDynamicSlot(slot, context, true),
     ),
   )
 }

--- a/packages/compiler-vapor/src/ir/component.ts
+++ b/packages/compiler-vapor/src/ir/component.ts
@@ -36,7 +36,7 @@ export enum IRSlotType {
   DYNAMIC,
   LOOP,
   CONDITIONAL,
-  EXPRESSION,
+  EXPRESSION, // JSX only
 }
 export type IRSlotsStatic = {
   slotType: IRSlotType.STATIC

--- a/packages/compiler-vapor/src/ir/component.ts
+++ b/packages/compiler-vapor/src/ir/component.ts
@@ -36,6 +36,7 @@ export enum IRSlotType {
   DYNAMIC,
   LOOP,
   CONDITIONAL,
+  EXPRESSION,
 }
 export type IRSlotsStatic = {
   slotType: IRSlotType.STATIC
@@ -58,9 +59,13 @@ export interface IRSlotDynamicConditional {
   positive: IRSlotDynamicBasic
   negative?: IRSlotDynamicBasic | IRSlotDynamicConditional
 }
+export interface IRSlotsExpression {
+  slotType: IRSlotType.EXPRESSION
+  slots: SimpleExpressionNode
+}
 
 export type IRSlotDynamic =
   | IRSlotDynamicBasic
   | IRSlotDynamicLoop
   | IRSlotDynamicConditional
-export type IRSlots = IRSlotsStatic | IRSlotDynamic
+export type IRSlots = IRSlotsStatic | IRSlotDynamic | IRSlotsExpression


### PR DESCRIPTION
```tsx
<Comp v-slots={{ default: ({ foo })=> <>{ foo }</> }}></Comp>
```