### PR TITLE
chore: bump node version on netlify

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,3 @@
 [build.environment]
-  NODE_VERSION = "18"
+  NODE_VERSION = "22"
   NPM_FLAGS = "--version" # prevent Netlify npm install


### PR DESCRIPTION
Since node 22 is now stable, we may use version 22 here.